### PR TITLE
change voltageL1N to optional

### DIFF
--- a/evnex/schema/v3/charge_points.py
+++ b/evnex/schema/v3/charge_points.py
@@ -26,7 +26,7 @@ class EvnexChargePointConnectorMeter(BaseModel):
     power: float
     _register: float = Field(alias="register")
     updatedDate: datetime
-    voltageL1N: float
+    voltageL1N: Optional[float]
 
 
 class EvnexChargePointConnector(BaseModel):


### PR DESCRIPTION
Some early versions of firmware may not report voltage
```
"meter": {
                        "currentL1": 0.054,
                        "frequency": 50,
                        "power": 0,
                        "register": 1133364,
                        "updatedDate": "2022-02-13T00:45:00.000Z"
                    },
```