### PR TITLE
Add Installer user type

### DIFF
--- a/evnex/schema/user.py
+++ b/evnex/schema/user.py
@@ -14,7 +14,7 @@ class EvnexUserDetail(BaseModel):
     name: str
     email: str
     organisations: list[EvnexOrgBrief]
-    type: Literal["User"] = "User"
+    type: Literal["User","Installer"] = "User"
 
 
 class EvnexGetUserResponse(BaseModel):


### PR DESCRIPTION
Looks like there may be some changes in the api, I have been getting this error:
```
pydantic.error_wrappers.ValidationError: 1 validation error for EvnexGetUserResponse
data -> type
  unexpected value; permitted: 'User' (type=value_error.const; given=Installer; permitted=('User',))
```