### PR TITLE
Relax python dep for HA 2023.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ issues = "https://github.com/hardbyte/python-evnex/issues"
 
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = ">=3.10"
 httpx = "^0.23"
 pycognito = "^2022.11"
 pydantic = "^1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "evnex"
-version = "0.3.3"
+version = "0.3.4"
 description = "A Python wrapper for the EVNEX Cloud API"
 authors = ["Brian Thorne <brian@hardbyte.nz>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ issues = "https://github.com/hardbyte/python-evnex/issues"
 
 [tool.poetry.dependencies]
 python = ">=3.10"
-httpx = "^0.23"
+httpx = ">=0.23,<0.25"
 pycognito = "^2022.11"
 pydantic = "^1.10"
 tenacity = "^8.1"


### PR DESCRIPTION
NB httpx constraints need to be relaxed too. Not sure why dependabot hasn't already created PR?