### PR TITLE
add additional phases as well as get-status api call to get charger s…

### DIFF
--- a/evnex/api.py
+++ b/evnex/api.py
@@ -23,7 +23,7 @@ from evnex.schema.charge_points import (
     EvnexGetChargePointTransactionsResponse,
     EvnexGetChargePointDetailResponse,
     EvnexGetChargePointsResponse,
-    EvnexChargePointStatus,
+    EvnexChargePointStatusResponse,
 )
 from evnex.schema.commands import EvnexCommandResponse
 from evnex.schema.org import (
@@ -330,7 +330,7 @@ class Evnex:
     )
     async def get_charge_point_status(
         self, charge_point_id: str
-    ) -> EvnexChargePointStatus:
+    ) -> EvnexChargePointStatusResponse:
         """
         :param charge_point_id:
         :raises: ReadTimeout if the charge point is offline.
@@ -341,7 +341,7 @@ class Evnex:
         )
         json_data = await self._check_api_response(r)
 
-        return EvnexChargePointStatus.model_validate(json_data)
+        return EvnexChargePointStatusResponse.model_validate(json_data)
 
     @retry(
         wait=wait_random_exponential(multiplier=1, max=60),

--- a/evnex/schema/charge_points.py
+++ b/evnex/schema/charge_points.py
@@ -1,9 +1,58 @@
 from datetime import datetime
+from enum import StrEnum
 from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
 from evnex.schema.cost import EvnexCost
+
+
+class ChargingLogic(StrEnum):
+    UNAVAILABLE = "Unavailable"
+    NOVEHICLE = "NoVehicle"
+    VEHICLE = "Vehicle"
+    TRANSFER = "Transfer"
+    FAULT = "Fault"
+
+
+class ChargingCurrentControl(StrEnum):
+    FULLPOWER = "FullPower"
+    THERMALLIMITED = "ThermalLimited"
+    LLMLIMITED = "LLMLimited"
+    WAITINGSCHEDULE = "WaitingSchedule"
+    WAITINGSOLAR = "WaitingSolar"
+    SOLARCONTROL = "SolarControl"
+    SCHEDULELIMITED = "ScheduleLimited"
+    SUPPLYLIMITED = "SupplyLimited"
+
+
+class E2LEDState(StrEnum):
+    OFF = "Off"
+    IDLE = "Idle"
+    CHARGING = "Charging"
+    CHARGENOWCHARGING = "ChargeNowCharging"
+    CHARGENOWNOTCHARGING = "ChargeNowNotCharging"
+    FAULT = "Fault"
+    DISABLED = "Disabled"
+    WAITSCHEDULE = "WaitSchedule"
+    WAITSOLAR = "WaitSolar"
+    WAITVEHICLE = "WaitVehicle"
+    SHUTTINGDOWN = "ShuttingDown"
+
+
+class AntiSleepState(StrEnum):
+    DISABLED = "Disabled"
+    ENABLED = "Enabled"
+    ACTIVE = "Active"
+    NA = "NA"
+
+
+class ChargePointStatus(BaseModel):
+    chargeNow: bool
+    chargingLogic: ChargingLogic
+    chargingCurrentControl: ChargingCurrentControl
+    LEDState: E2LEDState
+    AntiSleep: AntiSleepState
 
 
 class EvnexChargePointConnectorMeter(BaseModel):
@@ -12,6 +61,7 @@ class EvnexChargePointConnectorMeter(BaseModel):
     power: float
     raw_register: float = Field(..., alias="register")
     frequency: float
+    temperature: float
 
 
 class Coordinates(BaseModel):
@@ -69,6 +119,11 @@ class EvnexChargePointSolarConfig(BaseModel):
 
 class EvnexChargePointOverrideConfig(BaseModel):
     chargeNow: bool | Literal["NotSupported"]
+
+
+class EvnexChargePointStatus(BaseModel):
+    commandResultStatus: str
+    chargePointStatus: Optional[ChargePointStatus] = None
 
 
 class EvnexChargePointBase(BaseModel):

--- a/evnex/schema/charge_points.py
+++ b/evnex/schema/charge_points.py
@@ -61,7 +61,6 @@ class EvnexChargePointConnectorMeter(BaseModel):
     power: float
     raw_register: float = Field(..., alias="register")
     frequency: float
-    temperature: float
 
 
 class Coordinates(BaseModel):
@@ -124,6 +123,10 @@ class EvnexChargePointOverrideConfig(BaseModel):
 class EvnexChargePointStatus(BaseModel):
     commandResultStatus: str
     chargePointStatus: Optional[ChargePointStatus] = None
+
+
+class EvnexChargePointStatusResponse(BaseModel):
+    data: EvnexChargePointStatus
 
 
 class EvnexChargePointBase(BaseModel):

--- a/evnex/schema/v3/charge_points.py
+++ b/evnex/schema/v3/charge_points.py
@@ -37,11 +37,16 @@ class EvnexChargeProfile(BaseModel):
 
 class EvnexChargePointConnectorMeter(BaseModel):
     currentL1: Optional[float] = None
+    currentL2: Optional[float] = None
+    currentL3: Optional[float] = None
     frequency: float
     power: float
     raw_register: float = Field(..., alias="register")
     updatedDate: datetime
+    temperature: float
     voltageL1N: Optional[float] = None
+    voltageL2N: Optional[float] = None
+    voltageL3N: Optional[float] = None
 
 
 class EvnexChargePointConnector(BaseModel):

--- a/evnex/status.py
+++ b/evnex/status.py
@@ -1,0 +1,28 @@
+from enum import StrEnum
+
+
+class DeviceStatus(StrEnum):
+    OFFLINE = "OFFLINE"
+    AVAILABLE = "AVAILABLE"
+    PREPARING = "PREPARING"
+    CHARGING = "CHARGING"
+    SUSPENDED_EVSE = "SUSPENDED_EVSE"
+    SUSPENDED_EV = "SUSPENDED_EV"
+    FINISHING = "FINISHING"
+    RESERVED = "RESERVED"
+    UNAVAILABLE = "UNAVAILABLE"
+    FAULTED = "FAULTED"
+
+
+ConnectorOcppStatus: dict[DeviceStatus, str] = {
+    DeviceStatus.AVAILABLE: "Available",
+    DeviceStatus.CHARGING: "Charging",
+    DeviceStatus.FAULTED: "Faulted",
+    DeviceStatus.FINISHING: "Finished charging - unplug charge point",
+    DeviceStatus.PREPARING: "Preparing to charge",
+    DeviceStatus.RESERVED: "Reserved",
+    DeviceStatus.SUSPENDED_EV: "The vehicle is not currently requesting energy",
+    DeviceStatus.SUSPENDED_EVSE: "Charging has been paused by the charge point",
+    DeviceStatus.UNAVAILABLE: "Disabled",
+    DeviceStatus.OFFLINE: "Offline",
+}

--- a/evnex/status.py
+++ b/evnex/status.py
@@ -12,17 +12,3 @@ class DeviceStatus(StrEnum):
     RESERVED = "RESERVED"
     UNAVAILABLE = "UNAVAILABLE"
     FAULTED = "FAULTED"
-
-
-ConnectorOcppStatus: dict[DeviceStatus, str] = {
-    DeviceStatus.AVAILABLE: "Available",
-    DeviceStatus.CHARGING: "Charging",
-    DeviceStatus.FAULTED: "Faulted",
-    DeviceStatus.FINISHING: "Finished charging - unplug charge point",
-    DeviceStatus.PREPARING: "Preparing to charge",
-    DeviceStatus.RESERVED: "Reserved",
-    DeviceStatus.SUSPENDED_EV: "The vehicle is not currently requesting energy",
-    DeviceStatus.SUSPENDED_EVSE: "Charging has been paused by the charge point",
-    DeviceStatus.UNAVAILABLE: "Disabled",
-    DeviceStatus.OFFLINE: "Offline",
-}

--- a/examples/get_charge_point_detail.py
+++ b/examples/get_charge_point_detail.py
@@ -45,6 +45,12 @@ async def main():
                 charge_point.serial,
                 charge_point.id,
             )
+            print("Getting charge point status")
+            charge_status = await evnex.get_charge_point_status(
+                charge_point_id=charge_point.id
+            )
+
+            print(charge_status)
 
             print("charge point details")
             charge_point_detail = await evnex.get_charge_point_detail_v3(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evnex"
-version = "0.4.6"
+version = "0.4.7"
 description = "A Python wrapper for the EVNEX Cloud API"
 authors = [{ name = "Brian Thorne", email = "brian@hardbyte.nz" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ requires-dist = [
     { name = "pycognito", specifier = ">=2023.5.0,<2025" },
     { name = "pydantic", specifier = ">2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.2,<3.0" },
-    { name = "tenacity", specifier = ">=8.1,<9.0" },
+    { name = "tenacity", specifier = ">=8.1,<10.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -239,7 +239,7 @@ wheels = [
 
 [[package]]
 name = "evnex"
-version = "0.4.6"
+version = "0.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
…tatus for what kind of suspend it is,e.g solar

based on models found in app.evnex.io I was able to determine a few extra bits such as the additional phases

also get-status returns useful information such as what kind of suspend the charger is in.

Found and created all types returned for general charger status.