### PR TITLE
Fix schema validation gaps: optional user name, expose supplyActivePower

### DIFF
--- a/evnex/schema/org.py
+++ b/evnex/schema/org.py
@@ -21,6 +21,7 @@ class EvnexOrgBrief(BaseModel):
 
 class EvnexOrgInsightEntry(BaseModel):
     carbonOffset: float
+    carbonUsage: float | None = None
     cost: EvnexCost
     duration: int
     powerUsage: float

--- a/evnex/schema/user.py
+++ b/evnex/schema/user.py
@@ -11,7 +11,8 @@ class EvnexUserDetail(BaseModel):
     id: UUID
     createdDate: datetime
     updatedDate: datetime
-    name: str
+    # The API omits name entirely for accounts that never set one
+    name: str | None = None
     email: str
     organisations: list[EvnexOrgBrief]
     type: Literal["User", "Installer"] = "User"

--- a/evnex/schema/v3/charge_points.py
+++ b/evnex/schema/v3/charge_points.py
@@ -52,6 +52,9 @@ class EvnexChargePointConnectorMeter(BaseModel):
     frequency: float
     power: float
     raw_register: float = Field(..., alias="register")
+    # Grid draw measured by the CT clamp; only present when a power sensor
+    # is installed (features.PowerSensor.unlocked)
+    supplyActivePower: float | None = None
     updatedDate: datetime
     temperature: float | None = None
     voltageL1N: float | None = None

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,49 @@
+"""Schema regression tests built from captured API payloads."""
+
+from evnex.schema.user import EvnexGetUserResponse
+from evnex.schema.v3.charge_points import EvnexChargePointConnectorMeter
+
+
+# https://github.com/hardbyte/python-evnex/issues/108
+def test_user_without_name_validates():
+    payload = {
+        "data": {
+            "id": "b102b5e3-2b00-4f6b-9b0c-b579c609f969",
+            "createdDate": "2022-01-01T00:00:00Z",
+            "updatedDate": "2022-01-01T00:00:00Z",
+            "email": "user@example.com",
+            "organisations": [],
+            "type": "User",
+        }
+    }
+    user = EvnexGetUserResponse.model_validate(payload).data
+    assert user.name is None
+    assert user.email == "user@example.com"
+
+
+# https://github.com/hardbyte/python-evnex/issues/109
+def test_connector_meter_exposes_supply_active_power():
+    # Captured from a live v3 charge point detail response for a charger
+    # with the PowerSensor feature (CT clamp) installed
+    payload = {
+        "currentL1": 24.2,
+        "frequency": 50,
+        "power": 5380,
+        "register": 7502488,
+        "supplyActivePower": 7730,
+        "updatedDate": "2026-07-16T10:25:00.000Z",
+        "voltageL1N": 222.3,
+    }
+    meter = EvnexChargePointConnectorMeter.model_validate(payload)
+    assert meter.supplyActivePower == 7730
+
+
+def test_connector_meter_without_power_sensor():
+    payload = {
+        "frequency": 50,
+        "power": 5380,
+        "register": 7502488,
+        "updatedDate": "2026-07-16T10:25:00.000Z",
+    }
+    meter = EvnexChargePointConnectorMeter.model_validate(payload)
+    assert meter.supplyActivePower is None


### PR DESCRIPTION
Fixes #108 — accounts with no name set fail validation because the API omits the field; it's now optional.

Addresses the library side of #109 — the v3 connector meter response includes `supplyActivePower` (grid draw from the CT clamp, when installed) but the schema silently dropped it. Now exposed as an optional field, so consumers like ha-evnex can surface it as a grid power sensor from the regular poll. `get_charge_point_energy_meter_reading()` already returns the same reading on demand. Also accepts the `carbonUsage` insights attribute observed in current API responses.

Schema regression tests added from captured payloads.