### PR TITLE
Replace proactive token checks with reactive 401 recovery (0.6.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ evnex.respond_to_mfa_challenge(code, "TOTP", mfa_tokens=challenge_session)
 
 To avoid interactive MFA on every start, store the tokens after a successful
 authentication and pass them back in later — the refresh token alone is
-enough. Access tokens are refreshed automatically when they expire:
+enough. When the API rejects an expired or revoked access token, the client
+refreshes it and retries the request automatically:
 
 ```python
 evnex = Evnex(username=username, password=password, refresh_token=refresh_token)

--- a/evnex/api.py
+++ b/evnex/api.py
@@ -104,12 +104,16 @@ def api_retry(*extra_non_retryable: type[BaseException]):
     )
 
 
-def refresh_token_if_expired(func):
-    """Decorator to ensure the token is valid before making an API call."""
+def ensure_authenticated(func):
+    """Decorator to ensure we hold session tokens before making an API call.
+
+    Token expiry is handled reactively: a 401 response triggers a refresh
+    and the request is retried (see Evnex._check_api_response).
+    """
 
     @wraps(func)
     async def wrapper(self, *args, **kwargs):
-        await self._ensure_valid_token()
+        await self._ensure_authenticated()
         return await func(self, *args, **kwargs)
 
     return wrapper
@@ -162,15 +166,16 @@ class Evnex:
 
         self.version = EVNEX_VERSION
 
-    async def _ensure_valid_token(self) -> bool:
-        """Ensure we hold a valid access token, authenticating or refreshing as needed.
+    async def _ensure_authenticated(self) -> None:
+        """Ensure we hold session tokens, signing in on first use.
 
-        Returns True if new tokens were obtained.
-
-        :raises NotAuthorizedException: authentication or token refresh failed
+        :raises NotAuthorizedException: authentication failed
         :raises SoftwareTokenMFAChallengeException: respond with a TOTP app code
         :raises SMSMFAChallengeException: respond with a code sent by SMS
         """
+        if self.cognito.access_token is not None and self._resumed_tokens_verified:
+            return
+
         async with self._token_lock:
             if self.cognito.access_token is None:
                 if self.cognito.refresh_token:
@@ -182,27 +187,32 @@ class Evnex:
                 else:
                     logger.debug("No tokens, starting cognito auth flow")
                     await asyncio.to_thread(self.authenticate)
-                self._resumed_tokens_verified = True
-                return True
-
-            logger.debug("Checking if JWT tokens need to be refreshed")
-            try:
-                # check_token() renews via the refresh token if expired
-                renewed = bool(await asyncio.to_thread(self.cognito.check_token))
-            except botocore.exceptions.ClientError as e:
-                logger.error(f"Failed to refresh token: {e}")
-                raise NotAuthorizedException(str(e)) from e
-
-            if renewed:
-                # pycognito verifies newly issued tokens in _set_tokens
-                self._resumed_tokens_verified = True
             elif not self._resumed_tokens_verified:
                 try:
                     await asyncio.to_thread(self.cognito.verify_tokens)
                 except TokenVerificationException as e:
                     raise NotAuthorizedException(str(e)) from e
-                self._resumed_tokens_verified = True
-            return renewed
+            self._resumed_tokens_verified = True
+
+    async def _refresh_session(self, stale_access_token: str | None) -> None:
+        """Obtain fresh tokens after the API rejected the current ones.
+
+        Single-flight: concurrent callers that failed with the same stale
+        token wait on the lock and return without a second refresh.
+
+        :raises NotAuthorizedException: the session could not be renewed
+        """
+        async with self._token_lock:
+            if self.cognito.access_token != stale_access_token:
+                return
+            logger.debug("API rejected the session token, refreshing")
+            try:
+                if self.cognito.refresh_token:
+                    await asyncio.to_thread(self.cognito.renew_access_token)
+                else:
+                    await asyncio.to_thread(self.authenticate)
+            except botocore.exceptions.ClientError as e:
+                raise NotAuthorizedException(str(e)) from e
 
     @property
     def _common_headers(self):
@@ -283,7 +293,7 @@ class Evnex:
         return self.cognito.refresh_token
 
     @api_retry()
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_user_detail(self) -> EvnexUserDetail:
         response = await self.httpx_client.get(
             "https://client-api.evnex.io/v2/apps/user", headers=self._common_headers
@@ -299,13 +309,14 @@ class Evnex:
 
     async def _check_api_response(self, response):
         if response.status_code == 401:
-            logger.debug("Got a 401, attempting to refresh tokens")
-            if await self._ensure_valid_token():
-                # New tokens were obtained: the retry policy re-sends the
-                # request with them. A persistent 401 surfaces to the caller
-                # as NotAuthorizedException via _raise_final_attempt.
-                raise TokenRefreshedError()
-            raise NotAuthorizedException()
+            # A 401 means the server rejected the request before executing
+            # it, so re-sending with fresh tokens is safe even for commands.
+            # The retry policy re-sends; a persistent 401 surfaces to the
+            # caller as NotAuthorizedException via _raise_final_attempt.
+            await self._refresh_session(
+                stale_access_token=response.request.headers.get("Authorization")
+            )
+            raise TokenRefreshedError()
         if not response.is_success:
             logger.warning(
                 f"Unsuccessful request\n{response.status_code}\n{response.text}"
@@ -325,7 +336,7 @@ class Evnex:
             raise
 
     @api_retry(HTTPStatusError)
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_org_charge_points(
         self, org_id: str | None = None
     ) -> list[EvnexChargePoint]:
@@ -340,7 +351,7 @@ class Evnex:
         return EvnexGetChargePointsResponse.model_validate(json_data).data.items
 
     @api_retry()
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_org_insight(
         self, days: int, org_id: str | None = None, tz_offset: int = 12
     ) -> list[EvnexOrgInsightEntry]:
@@ -358,7 +369,7 @@ class Evnex:
         return [insight.attributes for insight in validated_data]
 
     @api_retry()
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_org_summary_status(
         self, org_id: str | None = None
     ) -> EvnexOrgSummaryStatus:
@@ -373,7 +384,7 @@ class Evnex:
         return EvnexGetOrgSummaryStatusResponse.model_validate(json_data).data
 
     @api_retry()
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_charge_point_detail(
         self, charge_point_id: str
     ) -> EvnexChargePointDetail:
@@ -390,7 +401,7 @@ class Evnex:
         return EvnexGetChargePointDetailResponse.model_validate(json_data).data
 
     @api_retry(TypeError)
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_charge_point_detail_v3(
         self, charge_point_id: str
     ) -> EvnexV3APIResponse[EvnexChargePointDetailV3]:
@@ -406,7 +417,7 @@ class Evnex:
         return EvnexV3APIResponse[EvnexChargePointDetailV3].model_validate(json_data)
 
     @api_retry(ReadTimeout)
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_charge_point_solar_config(
         self, charge_point_id: str
     ) -> EvnexChargePointSolarConfig:
@@ -423,7 +434,7 @@ class Evnex:
         return EvnexChargePointSolarConfig.model_validate(json_data)
 
     @api_retry(ReadTimeout)
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_charge_point_override(
         self, charge_point_id: str
     ) -> EvnexChargePointOverrideConfig:
@@ -441,7 +452,7 @@ class Evnex:
         return EvnexChargePointOverrideConfig.model_validate(json_data)
 
     @api_retry()
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def set_charge_point_override(
         self, charge_point_id: str, charge_now: bool, connector_id: int = 1
     ):
@@ -454,7 +465,7 @@ class Evnex:
         return True
 
     @api_retry(ReadTimeout)
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_charge_point_status(
         self, charge_point_id: str
     ) -> EvnexChargePointStatusResponse:
@@ -471,7 +482,7 @@ class Evnex:
         return EvnexChargePointStatusResponse.model_validate(json_data)
 
     @api_retry(ReadTimeout)
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_charge_point_energy_meter_reading(
         self, charge_point_id: str
     ) -> EvnexChargePointEnergyMeterReadingResponse:
@@ -488,7 +499,7 @@ class Evnex:
         return EvnexChargePointEnergyMeterReadingResponse.model_validate(json_data)
 
     @api_retry()
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_charge_point_transactions(
         self, charge_point_id: str
     ) -> list[EvnexChargePointTransaction]:
@@ -509,7 +520,7 @@ class Evnex:
         ).data.items
 
     @api_retry()
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def get_charge_point_sessions(
         self, charge_point_id: str
     ) -> list[EvnexChargePointSession]:
@@ -521,7 +532,7 @@ class Evnex:
         return EvnexGetChargePointSessionsResponse.model_validate(json_data).data
 
     @api_retry(ReadTimeout)
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def stop_charge_point(
         self,
         charge_point_id: str,
@@ -574,7 +585,7 @@ class Evnex:
             connector_id=connector_id,
         )
 
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def set_charger_availability(
         self,
         org_id: str,
@@ -604,7 +615,7 @@ class Evnex:
 
         return EvnexCommandResponseV3.model_validate(json_data["data"])
 
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def unlock_charger(
         self,
         charge_point_id: str,
@@ -633,7 +644,7 @@ class Evnex:
         json_data = await self._check_api_response(r)
         return EvnexCommandResponse.model_validate(json_data["data"])
 
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def set_charger_load_profile(
         self,
         charge_point_id: str,
@@ -671,7 +682,7 @@ class Evnex:
         json_data = await self._check_api_response(r)
         return EvnexChargePointLoadSchedule.model_validate(json_data["data"])
 
-    @refresh_token_if_expired
+    @ensure_authenticated
     async def set_charge_point_schedule(
         self,
         charge_point_id: str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evnex"
-version = "0.6.0"
+version = "0.6.1"
 description = "A Python wrapper for the EVNEX Cloud API"
 authors = [{ name = "Brian Thorne", email = "brian@hardbyte.nz" }]
 readme = "README.md"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,9 +30,10 @@ class FakeCognito:
         self.refresh_token = refresh_token
         self.access_token = access_token
         self.mfa_tokens = None
+        self._token_serial = 0
         self.authenticate = MagicMock(side_effect=self._issue_tokens)
         self.check_token = MagicMock(return_value=False, side_effect=self._block)
-        self.renew_access_token = MagicMock(side_effect=self._block)
+        self.renew_access_token = MagicMock(side_effect=self._rotate_tokens)
         self.verify_tokens = MagicMock(side_effect=self._block)
         self.respond_to_sms_mfa_challenge = MagicMock(side_effect=self._block)
         self.respond_to_software_token_mfa_challenge = MagicMock(
@@ -49,6 +50,12 @@ class FakeCognito:
         self.access_token = "access-0"
         self.id_token = "id-0"
         self.refresh_token = "refresh-0"
+
+    def _rotate_tokens(self):
+        self._block()
+        self._token_serial += 1
+        self.access_token = f"access-{self._token_serial}"
+        self.id_token = f"id-{self._token_serial}"
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -86,20 +86,21 @@ class TestFirstUseAuthentication:
 
 
 class TestTokenRefresh:
-    async def test_expired_token_renewed_before_request(self, authenticated_client):
-        authenticated_client.cognito.check_token.return_value = True
-
+    async def test_no_proactive_checks_on_happy_path(self, authenticated_client):
         with respx.mock:
             respx.get(USER_URL).mock(
                 return_value=httpx.Response(200, json=USER_PAYLOAD)
             )
-            user = await authenticated_client.get_user_detail()
+            await authenticated_client.get_user_detail()
+            await authenticated_client.get_user_detail()
 
-        assert user.name == "Test User"
-        authenticated_client.cognito.check_token.assert_called_once()
+        # Expiry is handled reactively via 401 responses, so successful
+        # requests never touch Cognito
+        authenticated_client.cognito.check_token.assert_not_called()
+        authenticated_client.cognito.renew_access_token.assert_not_called()
 
     async def test_refresh_failure_wrapped_and_not_retried(self, authenticated_client):
-        authenticated_client.cognito.check_token.side_effect = (
+        authenticated_client.cognito.renew_access_token.side_effect = (
             botocore.exceptions.ClientError(
                 {
                     "Error": {
@@ -111,9 +112,13 @@ class TestTokenRefresh:
             )
         )
 
-        with pytest.raises(NotAuthorizedException):
-            await authenticated_client.get_user_detail()
-        authenticated_client.cognito.check_token.assert_called_once()
+        with respx.mock:
+            route = respx.get(USER_URL).mock(return_value=httpx.Response(401))
+            with pytest.raises(NotAuthorizedException):
+                await authenticated_client.get_user_detail()
+
+        assert route.call_count == 1
+        authenticated_client.cognito.renew_access_token.assert_called_once()
 
     async def test_refresh_token_only_resumption(self):
         client = Evnex(
@@ -158,10 +163,7 @@ class TestResumedTokenVerification:
 
 
 class TestUnauthorizedResponses:
-    async def test_401_with_renewed_token_retries_request(self, authenticated_client):
-        # Valid before the first request; found expired+renewed after the 401
-        authenticated_client.cognito.check_token.side_effect = [False, True, False]
-
+    async def test_401_refreshes_and_retries_request(self, authenticated_client):
         with respx.mock:
             route = respx.get(USER_URL)
             route.side_effect = [
@@ -172,20 +174,28 @@ class TestUnauthorizedResponses:
 
         assert user.name == "Test User"
         assert route.call_count == 2
+        authenticated_client.cognito.renew_access_token.assert_called_once()
 
-    async def test_401_with_valid_token_fails_without_retry(self, authenticated_client):
+    async def test_401_reauthenticates_without_refresh_token(self, client):
+        # Sessions without a refresh token fall back to password auth
+        client.cognito.access_token = "access-0"
+        client.cognito.id_token = "id-0"
+
         with respx.mock:
-            route = respx.get(USER_URL).mock(return_value=httpx.Response(401))
-            with pytest.raises(NotAuthorizedException):
-                await authenticated_client.get_user_detail()
+            route = respx.get(USER_URL)
+            route.side_effect = [
+                httpx.Response(401),
+                httpx.Response(200, json=USER_PAYLOAD),
+            ]
+            user = await client.get_user_detail()
 
-        assert route.call_count == 1
+        assert user.name == "Test User"
+        client.cognito.authenticate.assert_called_once()
+        client.cognito.renew_access_token.assert_not_called()
 
     async def test_persistent_401_despite_renewals_exhausts_retries(
         self, authenticated_client
     ):
-        authenticated_client.cognito.check_token.return_value = True
-
         with respx.mock:
             route = respx.get(USER_URL).mock(return_value=httpx.Response(401))
             with pytest.raises(NotAuthorizedException):
@@ -193,6 +203,28 @@ class TestUnauthorizedResponses:
 
         # Bounded by stop_after_attempt(5), not an endless refresh loop
         assert route.call_count == 5
+
+    async def test_concurrent_401s_refresh_once(self, authenticated_client):
+        # Both coroutines fail with the same stale token; only the first
+        # holder of the lock refreshes, the other retries with new tokens
+        calls = 0
+
+        def respond(request):
+            nonlocal calls
+            calls += 1
+            if request.headers["Authorization"] == "access-0":
+                return httpx.Response(401)
+            return httpx.Response(200, json=USER_PAYLOAD)
+
+        with respx.mock:
+            respx.get(USER_URL).mock(side_effect=respond)
+            users = await asyncio.gather(
+                authenticated_client.get_user_detail(),
+                authenticated_client.get_user_detail(),
+            )
+
+        assert all(user.name == "Test User" for user in users)
+        authenticated_client.cognito.renew_access_token.assert_called_once()
 
 
 class TestMFAChallengeResponse:

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "evnex"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Reworked after more review rather than throttling the per-call JWT expiry checks, this removes them entirely, per the architectural direction in #113.

**Why reactive is more correct, not just simpler:** the server is the authority on token validity. The old `check_token()` path only refreshed when the *local clock* said the token had expired — a server-side-invalidated token failed with no retry at all. Now:

- API methods only ensure the client *holds* tokens (first-use sign-in, refresh-token resumption, deferred signature verification) — no clocks, no per-call JWT decodes, no debug spam
- A 401 triggers a **single-flight refresh**: concurrent requests that failed with the same stale token wait on the lock and reuse the new tokens (new concurrency test covers this)
- The failed request is re-sent — safe even for command endpoints, since a 401 is rejected before execution
- Sessions without a refresh token fall back to password re-auth; persistent 401s surface as `NotAuthorizedException`, bounded by the existing retry ceiling

The strict "exactly one refresh + one resend" semantics from #113 need the central request path and land with that refactor; this keeps the tenacity bound (5 attempts) as interim behaviour.

Version 0.6.1 — ha-evnex 0.8.0b1 will pin it.