### PR TITLE
Refactor auth into an async, persistence-aware token lifecycle (0.7.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,4 @@ dmypy.json
 cython_debug/
 .idea
 .zed/
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -26,92 +26,83 @@ pip install evnex
 
 ## Usage
 
+`EvnexAuth` handles signing in and keeping the session alive; the `Evnex`
+client uses it to call the API. Credentials establish a session once and are
+never stored:
+
 ```python
 import asyncio
-from pydantic import SecretStr
-from pydantic_settings import BaseSettings
+import os
+
 from evnex.api import Evnex
-
-
-class EvnexAuthDetails(BaseSettings):
-    EVNEX_CLIENT_USERNAME: str
-    EVNEX_CLIENT_PASSWORD: SecretStr
+from evnex.auth import EvnexAuth
 
 
 async def main():
-    creds = EvnexAuthDetails()
-    evnex = Evnex(username=creds.EVNEX_CLIENT_USERNAME,
-                  password=creds.EVNEX_CLIENT_PASSWORD.get_secret_value())
+    auth = EvnexAuth()
+    await auth.start_authentication(
+        os.environ["EVNEX_CLIENT_USERNAME"],
+        os.environ["EVNEX_CLIENT_PASSWORD"],
+    )
+    evnex = Evnex(auth=auth)
 
-    user_data = await evnex.get_user_detail()
-
-    for org in user_data.organisations:
-        print("Getting 7 day insight for", org.name, "User:", user_data.name)
-        insights = await evnex.get_org_insight(days=7, org_id=org.id)
-
-        for segment in insights:
-            print(segment)
+    user = await evnex.get_user_detail()
+    for org in user.organisations:
+        for entry in await evnex.get_org_insight(days=7, org_id=org.id):
+            print(org.name, entry)
 
 
-if __name__ == '__main__':
-    asyncio.run(main())
+asyncio.run(main())
 ```
 
-### Multifactor authentication
+### Multi-factor authentication
 
-Accounts with MFA enabled can't authenticate with username and password alone:
-the first API call raises a challenge exception. Catch it, obtain a code from
-the user, then respond to the challenge:
+If the account has MFA enabled, `start_authentication` returns an
+`AuthChallenge` instead of tokens. Show it to the user, collect their
+6-digit code, and answer it:
 
 ```python
-from pycognito.exceptions import (
-    SMSMFAChallengeException,
-    SoftwareTokenMFAChallengeException,
+from evnex.auth import AuthChallenge
+
+result = await auth.start_authentication(username, password)
+while isinstance(result, AuthChallenge):
+    code = input(f"Enter the 6-digit code ({result.name}): ")
+    result = await auth.respond_to_challenge(result, code)
+```
+
+Challenges are short-lived (a few minutes): `ChallengeExpiredError` means
+start over, while `InvalidChallengeResponseError` means the code was wrong
+and the same challenge can be retried. A challenge serializes to JSON
+(`to_dict()`/`from_dict()`), so a web backend or config flow can answer it
+in a later request or another process.
+
+### Staying signed in
+
+Store the tokens and resume later — the refresh token alone is enough, no
+password or MFA prompt. Expired sessions renew automatically; register
+`on_token_update` to be handed every newly issued token set, and it will
+have completed before any request uses the new tokens, so your stored copy
+can never fall behind one that's already in use:
+
+```python
+from evnex.auth import EvnexAuth, TokenSet
+
+async def save_tokens(tokens: TokenSet) -> None:
+    my_store.write(tokens.to_dict())
+
+auth = EvnexAuth(
+    tokens=TokenSet.from_dict(my_store.read()),
+    on_token_update=save_tokens,
 )
-
-evnex = Evnex(username=username, password=password)
-try:
-    evnex.authenticate()
-except SoftwareTokenMFAChallengeException:
-    code = input("Enter the 6-digit code from your authenticator application: ")
-    evnex.respond_to_mfa_challenge(code, "TOTP")
-except SMSMFAChallengeException:
-    code = input("Enter the 6-digit code you received by SMS: ")
-    evnex.respond_to_mfa_challenge(code, "SMS")
+evnex = Evnex(auth=auth)
+user = await evnex.get_user_detail()
 ```
 
-Note the Cognito challenge session is short-lived (around 3 minutes), so
-prompt for the code promptly.
+If a request is rejected mid-session, the client refreshes and retries it
+once, transparently. When the session truly can't be renewed, calls raise
+`ReauthenticationRequiredError` — run the interactive sign-in again.
 
-The pending challenge is stored on the `Evnex` instance, so the example above
-works because the same instance calls `authenticate()` and
-`respond_to_mfa_challenge()`. If the response happens somewhere else — a
-different process, or a web backend handling a later request — capture the
-challenge session from the exception and hand it to the new instance:
-
-```python
-try:
-    evnex.authenticate()
-except SoftwareTokenMFAChallengeException as challenge:
-    challenge_session = challenge.get_tokens()  # JSON-serializable dict
-
-# later, on a fresh Evnex instance
-evnex.respond_to_mfa_challenge(code, "TOTP", mfa_tokens=challenge_session)
-```
-
-### Resuming a session
-
-To avoid interactive MFA on every start, store the tokens after a successful
-authentication and pass them back in later — the refresh token alone is
-enough. When the API rejects an expired or revoked access token, the client
-refreshes it and retries the request automatically:
-
-```python
-evnex = Evnex(username=username, password=password, refresh_token=refresh_token)
-user_data = await evnex.get_user_detail()  # no MFA prompt needed
-```
-
-See `examples/get_token.py` for a complete MFA + token resumption flow.
+See `examples/get_token.py` for a complete sign-in and persistence flow.
 
 ## Examples
 

--- a/evnex/__init__.py
+++ b/evnex/__init__.py
@@ -1,0 +1,4 @@
+import logging
+
+# Library convention: emit nothing unless the application configures logging
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/evnex/api.py
+++ b/evnex/api.py
@@ -1,21 +1,11 @@
-import asyncio
 import logging
-from functools import wraps
 from importlib.metadata import PackageNotFoundError, version
-from typing import Literal
 from warnings import warn
 
-import botocore
 import pydantic
-from httpx import AsyncClient, HTTPStatusError, ReadTimeout
-from pycognito import Cognito
-from pycognito.exceptions import (
-    MFAChallengeException,
-    TokenVerificationException,
-)
+from httpx import AsyncClient, HTTPStatusError, ReadTimeout, Response
 from pydantic import ValidationError
 from pydantic_core import from_json
-from pydantic_settings import BaseSettings
 from tenacity import (
     retry,
     retry_if_not_exception_type,
@@ -23,7 +13,9 @@ from tenacity import (
     wait_random_exponential,
 )
 
-from evnex.errors import NotAuthorizedException, TokenRefreshedError
+from evnex.auth import EvnexAuth, EvnexHttpxAuth
+from evnex.config import EvnexConfig
+from evnex.errors import EvnexAuthError, ReauthenticationRequiredError
 from evnex.schema.charge_points import (
     EvnexChargePoint,
     EvnexChargePointDetail,
@@ -64,35 +56,18 @@ except PackageNotFoundError:
     EVNEX_VERSION = "unknown"
 
 
-class EvnexConfig(BaseSettings):
-    EVNEX_BASE_URL: str = "https://client-api.evnex.io"
-    EVNEX_COGNITO_USER_POOL_ID: str = "ap-southeast-2_zWnqo6ASv"
-    EVNEX_COGNITO_CLIENT_ID: str = "rol3lsv2vg41783550i18r7vi"
-    EVNEX_ORG_ID: str | None = None
-
-
 NON_RETRYABLE_EXCEPTIONS = (
     ValidationError,
-    NotAuthorizedException,
-    MFAChallengeException,
+    EvnexAuthError,
 )
-
-
-def _raise_final_attempt(retry_state):
-    """Called by tenacity once retries are exhausted."""
-    exception = retry_state.outcome.exception()
-    if isinstance(exception, TokenRefreshedError):
-        raise NotAuthorizedException(
-            "Request still unauthorized after refreshing tokens"
-        ) from exception
-    raise exception
 
 
 def api_retry(*extra_non_retryable: type[BaseException]):
     """Retry transient API failures with backoff.
 
-    Authentication failures, MFA challenges and validation errors are never
-    retried, nor are any exception types passed as arguments.
+    Authentication failures and validation errors are never retried, nor are
+    any exception types passed as arguments. Authentication recovery happens
+    in the transport layer (EvnexHttpxAuth), independent of this policy.
     """
     return retry(
         wait=wait_random_exponential(multiplier=1, max=60),
@@ -100,203 +75,59 @@ def api_retry(*extra_non_retryable: type[BaseException]):
         retry=retry_if_not_exception_type(
             NON_RETRYABLE_EXCEPTIONS + extra_non_retryable
         ),
-        retry_error_callback=_raise_final_attempt,
+        # Surface the final underlying exception, not tenacity's RetryError
+        reraise=True,
     )
-
-
-def ensure_authenticated(func):
-    """Decorator to ensure we hold session tokens before making an API call.
-
-    Token expiry is handled reactively: a 401 response triggers a refresh
-    and the request is retried (see Evnex._check_api_response).
-    """
-
-    @wraps(func)
-    async def wrapper(self, *args, **kwargs):
-        await self._ensure_authenticated()
-        return await func(self, *args, **kwargs)
-
-    return wrapper
 
 
 class Evnex:
     def __init__(
         self,
-        username: str,
-        password: str,
-        id_token=None,
-        refresh_token=None,
-        access_token=None,
-        config: EvnexConfig | None = None,
+        *,
+        auth: EvnexAuth,
         httpx_client: AsyncClient | None = None,
+        config: EvnexConfig | None = None,
     ):
         """
         Create an Evnex API client.
 
-        :param username:
-        :param password:
-        :param id_token: ID Token returned by authentication
-        :param refresh_token: Refresh Token returned by authentication
-        :param access_token: Access Token returned by authentication
-        :param httpx_client:
+        :param auth: the authentication component owning the session tokens
+        :param httpx_client: optionally share an httpx AsyncClient
+        :param config: override API endpoints or the default org
         """
         self.httpx_client = httpx_client or AsyncClient()
         if config is None:
             config = EvnexConfig()
-        logger.debug("Creating evnex api instance")
-        self.username = username
-        self.password = password
-
+        self.auth = auth
         self.org_id = config.EVNEX_ORG_ID
-
-        self.cognito = Cognito(
-            user_pool_id=config.EVNEX_COGNITO_USER_POOL_ID,
-            client_id=config.EVNEX_COGNITO_CLIENT_ID,
-            username=username,
-            id_token=id_token,
-            refresh_token=refresh_token,
-            access_token=access_token,
-        )
-
-        self._token_lock = asyncio.Lock()
-        # Tokens passed in by the caller haven't been through pycognito's
-        # signature verification; defer that to the first API call rather
-        # than doing network I/O in the constructor.
-        self._resumed_tokens_verified = access_token is None
-
         self.version = EVNEX_VERSION
-
-    async def _ensure_authenticated(self) -> None:
-        """Ensure we hold session tokens, signing in on first use.
-
-        :raises NotAuthorizedException: authentication failed
-        :raises SoftwareTokenMFAChallengeException: respond with a TOTP app code
-        :raises SMSMFAChallengeException: respond with a code sent by SMS
-        """
-        if self.cognito.access_token is not None and self._resumed_tokens_verified:
-            return
-
-        async with self._token_lock:
-            if self.cognito.access_token is None:
-                if self.cognito.refresh_token:
-                    logger.debug("No access token, renewing with refresh token")
-                    try:
-                        await asyncio.to_thread(self.cognito.renew_access_token)
-                    except botocore.exceptions.ClientError as e:
-                        raise NotAuthorizedException(str(e)) from e
-                else:
-                    logger.debug("No tokens, starting cognito auth flow")
-                    await asyncio.to_thread(self.authenticate)
-            elif not self._resumed_tokens_verified:
-                try:
-                    await asyncio.to_thread(self.cognito.verify_tokens)
-                except TokenVerificationException as e:
-                    raise NotAuthorizedException(str(e)) from e
-            self._resumed_tokens_verified = True
-
-    async def _refresh_session(self, stale_access_token: str | None) -> None:
-        """Obtain fresh tokens after the API rejected the current ones.
-
-        Single-flight: concurrent callers that failed with the same stale
-        token wait on the lock and return without a second refresh.
-
-        :raises NotAuthorizedException: the session could not be renewed
-        """
-        async with self._token_lock:
-            if self.cognito.access_token != stale_access_token:
-                return
-            logger.debug("API rejected the session token, refreshing")
-            try:
-                if self.cognito.refresh_token:
-                    await asyncio.to_thread(self.cognito.renew_access_token)
-                else:
-                    await asyncio.to_thread(self.authenticate)
-            except botocore.exceptions.ClientError as e:
-                raise NotAuthorizedException(str(e)) from e
+        self._base_url = config.EVNEX_BASE_URL.rstrip("/")
+        self._httpx_auth = EvnexHttpxAuth(auth)
 
     @property
     def _common_headers(self):
+        # Authorization is injected per-request by EvnexHttpxAuth
         return {
             "Accept": "application/json",
             "content-type": "application/json",
-            "Authorization": self.access_token,
             "User-Agent": f"python-evnex/{self.version}",
         }
 
-    def authenticate(self):
-        """
-        Authenticate the user and update the access_token.
-
-        Note this isn't usually required: API methods authenticate on first
-        use. Call it directly when the account may have multifactor
-        authentication enabled, catch the challenge exception, obtain a code
-        from the user, then call respond_to_mfa_challenge().
-
-        :raises NotAuthorizedException: authentication failed
-        :raises SoftwareTokenMFAChallengeException: respond with a TOTP app code
-        :raises SMSMFAChallengeException: respond with a code sent by SMS
-        """
-        logger.debug("Authenticating to EVNEX cloud api")
-        try:
-            self.cognito.authenticate(password=self.password)
-        except MFAChallengeException:
-            raise
-        except botocore.exceptions.ClientError as e:
-            raise NotAuthorizedException(e.args[0]) from e
-
-    def respond_to_mfa_challenge(
-        self,
-        mfa_code: str,
-        mode: Literal["SMS", "TOTP"],
-        mfa_tokens=None,
-    ):
-        """
-        Respond to a multifactor authentication challenge either via SMS or TOTP app.
-
-        The challenge session is kept on this instance by authenticate(); to
-        respond from a different instance or process, pass mfa_tokens from
-        the challenge exception's get_tokens(). Note Cognito challenge
-        sessions are short-lived (around 3 minutes).
-
-        :raises NotAuthorizedException: the code was rejected or the challenge expired
-        :raises ValueError: mode is not "SMS" or "TOTP"
-        """
-        logger.debug("MFA Challenge and response issued.")
-
-        try:
-            match mode:
-                case "SMS":
-                    self.cognito.respond_to_sms_mfa_challenge(
-                        mfa_code, mfa_tokens=mfa_tokens
-                    )
-                case "TOTP":
-                    self.cognito.respond_to_software_token_mfa_challenge(
-                        mfa_code, mfa_tokens=mfa_tokens
-                    )
-                case _:
-                    raise ValueError(
-                        f"Unknown MFA mode {mode!r}, expected 'SMS' or 'TOTP'"
-                    )
-        except botocore.exceptions.ClientError as e:
-            raise NotAuthorizedException(e.args[0]) from e
-
-    @property
-    def access_token(self):
-        return self.cognito.access_token
-
-    @property
-    def id_token(self):
-        return self.cognito.id_token
-
-    @property
-    def refresh_token(self):
-        return self.cognito.refresh_token
+    async def _request(self, method: str, path: str, **kwargs) -> Response:
+        """Single request path: base URL, headers, auth, and 401 recovery."""
+        return await self.httpx_client.request(
+            method,
+            f"{self._base_url}{path}",
+            headers=self._common_headers,
+            auth=self._httpx_auth,
+            **kwargs,
+        )
 
     @api_retry()
-    @ensure_authenticated
     async def get_user_detail(self) -> EvnexUserDetail:
-        response = await self.httpx_client.get(
-            "https://client-api.evnex.io/v2/apps/user", headers=self._common_headers
+        response = await self._request(
+            "GET",
+            "/v2/apps/user",
         )
         response_json = await self._check_api_response(response)
         data = EvnexGetUserResponse.model_validate(response_json).data
@@ -307,60 +138,52 @@ class Evnex:
 
         return data
 
-    async def _check_api_response(self, response):
+    def _ensure_success(self, response) -> None:
         if response.status_code == 401:
-            # A 401 means the server rejected the request before executing
-            # it, so re-sending with fresh tokens is safe even for commands.
-            # The retry policy re-sends; a persistent 401 surfaces to the
-            # caller as NotAuthorizedException via _raise_final_attempt.
-            await self._refresh_session(
-                stale_access_token=response.request.headers.get("Authorization")
+            # EvnexHttpxAuth already refreshed and re-sent once; a 401 here
+            # means the renewed session is still rejected
+            raise ReauthenticationRequiredError(
+                "Request still unauthorized after refreshing the session"
             )
-            raise TokenRefreshedError()
         if not response.is_success:
             logger.warning(
                 f"Unsuccessful request\n{response.status_code}\n{response.text}"
             )
-        # logger.debug(
-        #     f"Raw EVNEX API response.\n{response.status_code}\n{response.text}"
-        # )
-
         response.raise_for_status()
+
+    async def _check_api_response(self, response):
+        self._ensure_success(response)
 
         try:
             return from_json(response.text)
-        except:
+        except Exception:
             logger.debug(
                 f"Invalid json response.\n{response.status_code}\n{response.text}"
             )
             raise
 
     @api_retry(HTTPStatusError)
-    @ensure_authenticated
     async def get_org_charge_points(
         self, org_id: str | None = None
     ) -> list[EvnexChargePoint]:
         if org_id is None and self.org_id:
             org_id = self.org_id
-        logger.debug("Listing org charge points")
-        r = await self.httpx_client.get(
-            f"https://client-api.evnex.io/v2/apps/organisations/{org_id}/charge-points",
-            headers=self._common_headers,
+        r = await self._request(
+            "GET",
+            f"/v2/apps/organisations/{org_id}/charge-points",
         )
         json_data = await self._check_api_response(r)
         return EvnexGetChargePointsResponse.model_validate(json_data).data.items
 
     @api_retry()
-    @ensure_authenticated
     async def get_org_insight(
         self, days: int, org_id: str | None = None, tz_offset: int = 12
     ) -> list[EvnexOrgInsightEntry]:
         if org_id is None and self.org_id:
             org_id = self.org_id
-        logger.debug("Getting org insight")
-        r = await self.httpx_client.get(
-            f"https://client-api.evnex.io/organisations/{org_id}/summary/insights",
-            headers=self._common_headers,
+        r = await self._request(
+            "GET",
+            f"/organisations/{org_id}/summary/insights",
             params={"days": days, "tz-offset": tz_offset},
         )
         json_data = await self._check_api_response(r)
@@ -369,22 +192,19 @@ class Evnex:
         return [insight.attributes for insight in validated_data]
 
     @api_retry()
-    @ensure_authenticated
     async def get_org_summary_status(
         self, org_id: str | None = None
     ) -> EvnexOrgSummaryStatus:
         if org_id is None and self.org_id:
             org_id = self.org_id
-        logger.debug("Getting org summary status")
-        r = await self.httpx_client.get(
-            f"https://client-api.evnex.io/v2/apps/organisations/{org_id}/summary/status",
-            headers=self._common_headers,
+        r = await self._request(
+            "GET",
+            f"/v2/apps/organisations/{org_id}/summary/status",
         )
         json_data = await self._check_api_response(r)
         return EvnexGetOrgSummaryStatusResponse.model_validate(json_data).data
 
     @api_retry()
-    @ensure_authenticated
     async def get_charge_point_detail(
         self, charge_point_id: str
     ) -> EvnexChargePointDetail:
@@ -393,31 +213,26 @@ class Evnex:
             DeprecationWarning,
             stacklevel=2,
         )
-        r = await self.httpx_client.get(
-            f"https://client-api.evnex.io/v2/apps/charge-points/{charge_point_id}",
-            headers=self._common_headers,
+        r = await self._request(
+            "GET",
+            f"/v2/apps/charge-points/{charge_point_id}",
         )
         json_data = await self._check_api_response(r)
         return EvnexGetChargePointDetailResponse.model_validate(json_data).data
 
     @api_retry(TypeError)
-    @ensure_authenticated
     async def get_charge_point_detail_v3(
         self, charge_point_id: str
     ) -> EvnexV3APIResponse[EvnexChargePointDetailV3]:
-        r = await self.httpx_client.get(
-            f"https://client-api.evnex.io/charge-points/{charge_point_id}",
-            headers=self._common_headers,
-        )
-        logger.debug(
-            f"Raw get charge point detail response.\n{r.status_code}\n{r.text}"
+        r = await self._request(
+            "GET",
+            f"/charge-points/{charge_point_id}",
         )
         json_data = await self._check_api_response(r)
 
         return EvnexV3APIResponse[EvnexChargePointDetailV3].model_validate(json_data)
 
     @api_retry(ReadTimeout)
-    @ensure_authenticated
     async def get_charge_point_solar_config(
         self, charge_point_id: str
     ) -> EvnexChargePointSolarConfig:
@@ -425,16 +240,15 @@ class Evnex:
         :param charge_point_id:
         :raises: ReadTimeout if the charge point is offline.
         """
-        r = await self.httpx_client.post(
-            f"https://client-api.evnex.io/charge-points/{charge_point_id}/commands/get-solar",
-            headers=self._common_headers,
+        r = await self._request(
+            "POST",
+            f"/charge-points/{charge_point_id}/commands/get-solar",
         )
         json_data = await self._check_api_response(r)
 
         return EvnexChargePointSolarConfig.model_validate(json_data)
 
     @api_retry(ReadTimeout)
-    @ensure_authenticated
     async def get_charge_point_override(
         self, charge_point_id: str
     ) -> EvnexChargePointOverrideConfig:
@@ -443,29 +257,27 @@ class Evnex:
         :param charge_point_id:
         :raises: ReadTimeout if the charge point is offline.
         """
-        r = await self.httpx_client.post(
-            f"https://client-api.evnex.io/charge-points/{charge_point_id}/commands/get-override",
-            headers=self._common_headers,
+        r = await self._request(
+            "POST",
+            f"/charge-points/{charge_point_id}/commands/get-override",
             timeout=15,
         )
         json_data = await self._check_api_response(r)
         return EvnexChargePointOverrideConfig.model_validate(json_data)
 
-    @api_retry()
-    @ensure_authenticated
+    @api_retry(HTTPStatusError)
     async def set_charge_point_override(
         self, charge_point_id: str, charge_now: bool, connector_id: int = 1
     ):
-        r = await self.httpx_client.post(
-            f"https://client-api.evnex.io/charge-points/{charge_point_id}/commands/set-override",
-            headers=self._common_headers,
+        r = await self._request(
+            "POST",
+            f"/charge-points/{charge_point_id}/commands/set-override",
             json={"connectorId": connector_id, "chargeNow": charge_now},
         )
-        r.raise_for_status()
+        self._ensure_success(r)
         return True
 
     @api_retry(ReadTimeout)
-    @ensure_authenticated
     async def get_charge_point_status(
         self, charge_point_id: str
     ) -> EvnexChargePointStatusResponse:
@@ -473,16 +285,15 @@ class Evnex:
         :param charge_point_id:
         :raises: ReadTimeout if the charge point is offline.
         """
-        r = await self.httpx_client.post(
-            f"https://client-api.evnex.io/charge-points/{charge_point_id}/commands/get-status",
-            headers=self._common_headers,
+        r = await self._request(
+            "POST",
+            f"/charge-points/{charge_point_id}/commands/get-status",
         )
         json_data = await self._check_api_response(r)
 
         return EvnexChargePointStatusResponse.model_validate(json_data)
 
     @api_retry(ReadTimeout)
-    @ensure_authenticated
     async def get_charge_point_energy_meter_reading(
         self, charge_point_id: str
     ) -> EvnexChargePointEnergyMeterReadingResponse:
@@ -490,16 +301,15 @@ class Evnex:
         :param charge_point_id:
         :raises: ReadTimeout if the charge point is offline.
         """
-        r = await self.httpx_client.post(
-            f"https://client-api.evnex.io/charge-points/{charge_point_id}/commands/get-energy-meter-reading",
-            headers=self._common_headers,
+        r = await self._request(
+            "POST",
+            f"/charge-points/{charge_point_id}/commands/get-energy-meter-reading",
         )
         json_data = await self._check_api_response(r)
 
         return EvnexChargePointEnergyMeterReadingResponse.model_validate(json_data)
 
     @api_retry()
-    @ensure_authenticated
     async def get_charge_point_transactions(
         self, charge_point_id: str
     ) -> list[EvnexChargePointTransaction]:
@@ -508,11 +318,10 @@ class Evnex:
             DeprecationWarning,
             stacklevel=2,
         )
-        # Similar to f'https://client-api.evnex.io/v3/charge-points/{charge_point_id}/sessions',
 
-        r = await self.httpx_client.get(
-            f"https://client-api.evnex.io/v2/apps/charge-points/{charge_point_id}/transactions",
-            headers=self._common_headers,
+        r = await self._request(
+            "GET",
+            f"/v2/apps/charge-points/{charge_point_id}/transactions",
         )
         json_data = await self._check_api_response(r)
         return EvnexGetChargePointTransactionsResponse.model_validate(
@@ -520,19 +329,17 @@ class Evnex:
         ).data.items
 
     @api_retry()
-    @ensure_authenticated
     async def get_charge_point_sessions(
         self, charge_point_id: str
     ) -> list[EvnexChargePointSession]:
-        r = await self.httpx_client.get(
-            f"https://client-api.evnex.io/charge-points/{charge_point_id}/sessions",
-            headers=self._common_headers,
+        r = await self._request(
+            "GET",
+            f"/charge-points/{charge_point_id}/sessions",
         )
         json_data = await self._check_api_response(r)
         return EvnexGetChargePointSessionsResponse.model_validate(json_data).data
 
-    @api_retry(ReadTimeout)
-    @ensure_authenticated
+    @api_retry(HTTPStatusError, ReadTimeout)
     async def stop_charge_point(
         self,
         charge_point_id: str,
@@ -554,9 +361,9 @@ class Evnex:
         if org_id is None and self.org_id:
             org_id = self.org_id
         logger.info("Stopping charging session")
-        r = await self.httpx_client.post(
-            f"https://client-api.evnex.io/v2/apps/organisations/{org_id}/charge-points/{charge_point_id}/commands/remote-stop-transaction",
-            headers=self._common_headers,
+        r = await self._request(
+            "POST",
+            f"/v2/apps/organisations/{org_id}/charge-points/{charge_point_id}/commands/remote-stop-transaction",
             # 'Connection': 'Keep-Alive'
             json={"connectorId": connector_id},
             timeout=timeout,
@@ -585,7 +392,6 @@ class Evnex:
             connector_id=connector_id,
         )
 
-    @ensure_authenticated
     async def set_charger_availability(
         self,
         org_id: str,
@@ -605,9 +411,9 @@ class Evnex:
         """
         availability = "Operative" if available else "Inoperative"
         logger.info(f"Changing connector {connector_id} to {availability}")
-        r = await self.httpx_client.post(
-            f"https://client-api.evnex.io/v2/apps/organisations/{org_id}/charge-points/{charge_point_id}/commands/change-availability",
-            headers=self._common_headers,
+        r = await self._request(
+            "POST",
+            f"/v2/apps/organisations/{org_id}/charge-points/{charge_point_id}/commands/change-availability",
             json={"connectorId": connector_id, "changeAvailabilityType": availability},
             timeout=timeout,
         )
@@ -615,7 +421,6 @@ class Evnex:
 
         return EvnexCommandResponseV3.model_validate(json_data["data"])
 
-    @ensure_authenticated
     async def unlock_charger(
         self,
         charge_point_id: str,
@@ -635,16 +440,15 @@ class Evnex:
         """
         availability = "Operative" if available else "Inoperative"
         logger.info(f"Changing connector {connector_id} to {availability}")
-        r = await self.httpx_client.post(
-            f"https://client-api.evnex.io/v2/apps/organisations/{self.org_id}/charge-points/{charge_point_id}/commands/unlock-connector",
-            headers=self._common_headers,
+        r = await self._request(
+            "POST",
+            f"/v2/apps/organisations/{self.org_id}/charge-points/{charge_point_id}/commands/unlock-connector",
             json={"connectorId": connector_id, "changeAvailabilityType": availability},
             timeout=timeout,
         )
         json_data = await self._check_api_response(r)
         return EvnexCommandResponse.model_validate(json_data["data"])
 
-    @ensure_authenticated
     async def set_charger_load_profile(
         self,
         charge_point_id: str,
@@ -668,9 +472,9 @@ class Evnex:
             )
         ]
 
-        r = await self.httpx_client.put(
-            f"https://client-api.evnex.io/v2/apps/charge-points/{charge_point_id}/load-management",
-            headers=self._common_headers,
+        r = await self._request(
+            "PUT",
+            f"/v2/apps/charge-points/{charge_point_id}/load-management",
             json={
                 "chargingProfilePeriods": schedule,
                 "enabled": enabled,
@@ -682,7 +486,6 @@ class Evnex:
         json_data = await self._check_api_response(r)
         return EvnexChargePointLoadSchedule.model_validate(json_data["data"])
 
-    @ensure_authenticated
     async def set_charge_point_schedule(
         self,
         charge_point_id: str,
@@ -710,9 +513,9 @@ class Evnex:
             )
         ]
 
-        r = await self.httpx_client.put(
-            f"https://client-api.evnex.io/v2/apps/charge-points/{charge_point_id}/charge-schedule",
-            headers=self._common_headers,
+        r = await self._request(
+            "PUT",
+            f"/v2/apps/charge-points/{charge_point_id}/charge-schedule",
             json={
                 "chargingProfilePeriods": schedule,
                 "enabled": enabled,

--- a/evnex/auth.py
+++ b/evnex/auth.py
@@ -1,0 +1,420 @@
+"""Authentication and session lifecycle for the EVNEX Cloud API.
+
+EvnexAuth signs in, answers MFA challenges, refreshes expired sessions, and
+notifies the application whenever new tokens are issued so they can be
+persisted. The Evnex client uses it to authenticate every request and to
+recover transparently when the API rejects a token.
+
+The underlying identity provider client (pycognito/boto3) is synchronous,
+and no maintained async equivalent exists, so those calls run in worker
+threads via asyncio.to_thread — nothing here blocks the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import botocore.exceptions
+import httpx
+import jwt
+from pycognito import Cognito
+from pycognito.exceptions import (
+    ForceChangePasswordException,
+    MFAChallengeException,
+    TokenVerificationException,
+    WarrantException,
+)
+
+from evnex.config import EvnexConfig
+from evnex.errors import (
+    ChallengeExpiredError,
+    EvnexAuthError,
+    InvalidChallengeResponseError,
+    InvalidCredentialsError,
+    PasswordChangeRequiredError,
+    ReauthenticationRequiredError,
+)
+
+logger = logging.getLogger("evnex.auth")
+
+CHALLENGE_SOFTWARE_TOKEN_MFA = "SOFTWARE_TOKEN_MFA"
+CHALLENGE_SMS_MFA = "SMS_MFA"
+
+# Refresh this long before the access token's recorded expiry, to absorb
+# clock skew between us and the API
+EXPIRY_SKEW = timedelta(seconds=30)
+
+TokenUpdateCallback = Callable[["TokenSet"], Awaitable[None]]
+
+# Sentinel distinguishing "always refresh" from "refresh unless the tokens
+# already rotated past this stale access token (which may be None)"
+_ALWAYS_REFRESH: Any = object()
+
+
+def _decode_expiry(access_token: str) -> datetime | None:
+    """Best-effort read of the JWT exp claim; the server stays authoritative."""
+    try:
+        claims = jwt.decode(access_token, options={"verify_signature": False})
+        return datetime.fromtimestamp(claims["exp"], tz=UTC)
+    except (jwt.DecodeError, KeyError, TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True, slots=True)
+class TokenSet:
+    """An immutable set of session tokens, safe to persist and to log."""
+
+    access_token: str | None = field(repr=False, default=None)
+    id_token: str | None = field(repr=False, default=None)
+    refresh_token: str | None = field(repr=False, default=None)
+    expires_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        if self.expires_at is None and self.access_token:
+            object.__setattr__(self, "expires_at", _decode_expiry(self.access_token))
+        elif self.expires_at is not None and self.expires_at.tzinfo is None:
+            # Treat naive datetimes from external stores as UTC so expiry
+            # comparisons never raise
+            object.__setattr__(self, "expires_at", self.expires_at.replace(tzinfo=UTC))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "access_token": self.access_token,
+            "id_token": self.id_token,
+            "refresh_token": self.refresh_token,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> TokenSet:
+        expires_at = data.get("expires_at")
+        if isinstance(expires_at, str):
+            expires_at = datetime.fromisoformat(expires_at)
+        return cls(
+            access_token=data.get("access_token"),
+            id_token=data.get("id_token"),
+            refresh_token=data.get("refresh_token"),
+            expires_at=expires_at,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class AuthChallenge:
+    """A pending Cognito authentication challenge.
+
+    JSON-serializable via to_dict/from_dict so a challenge can be answered
+    by a different process or a later request (within the short session
+    lifetime, around 3 minutes).
+    """
+
+    name: str
+    session: str = field(repr=False)
+    username: str = field(repr=False)
+    parameters: Mapping[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "session": self.session,
+            "username": self.username,
+            "parameters": dict(self.parameters),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> AuthChallenge:
+        return cls(
+            name=data["name"],
+            session=data["session"],
+            username=data["username"],
+            parameters=dict(data.get("parameters") or {}),
+        )
+
+
+class EvnexAuth:
+    """Manages sign-in, MFA, and session renewal for an EVNEX account.
+
+    Sign in interactively with start_authentication() (answering any
+    AuthChallenge via respond_to_challenge()), or resume a previous session
+    by passing tokens — a refresh token alone is enough. Expired sessions
+    renew automatically; provide on_token_update to persist each newly
+    issued token set, and it will have completed before any request uses
+    the new tokens. Credentials themselves are never stored.
+    """
+
+    def __init__(
+        self,
+        *,
+        tokens: TokenSet | None = None,
+        on_token_update: TokenUpdateCallback | None = None,
+        config: EvnexConfig | None = None,
+    ) -> None:
+        self._config = config or EvnexConfig()
+        self._tokens = tokens
+        self._on_token_update = on_token_update
+        # Serialises every operation that talks to Cognito or replaces
+        # self._tokens: it makes refreshes single-flight, and it means the
+        # mutable Cognito instance below is only ever used by one worker
+        # thread at a time. It deliberately does NOT guard reads of
+        # self._tokens — get_access_token's fast path reads the current
+        # token set lock-free, which is safe because _store_tokens replaces
+        # it with a single reference assignment, only after persistence.
+        self._lock = asyncio.Lock()
+        # Built lazily inside a worker thread: boto3 client construction
+        # performs blocking I/O (credential lookup)
+        self._cognito: Cognito | None = None
+
+    @property
+    def tokens(self) -> TokenSet | None:
+        """The current token set, if any."""
+        return self._tokens
+
+    async def start_authentication(
+        self, username: str, password: str
+    ) -> TokenSet | AuthChallenge:
+        """Begin interactive sign-in with the user's credentials.
+
+        Returns a TokenSet on immediate success, or an AuthChallenge that
+        must be answered via respond_to_challenge().
+
+        :raises InvalidCredentialsError: the credentials were rejected
+        """
+
+        def _authenticate() -> TokenSet | AuthChallenge:
+            cognito = self._ensure_cognito()
+            cognito.username = username
+            try:
+                cognito.authenticate(password=password)
+            except MFAChallengeException as challenge:
+                payload = challenge.get_tokens()
+                return AuthChallenge(
+                    name=payload["ChallengeName"],
+                    session=payload["Session"],
+                    username=username,
+                    parameters=dict(payload.get("ChallengeParameters") or {}),
+                )
+            return self._tokens_from_cognito(cognito)
+
+        async with self._lock:
+            try:
+                result = await asyncio.to_thread(_authenticate)
+            except botocore.exceptions.ClientError as err:
+                raise InvalidCredentialsError(_error_message(err)) from err
+            except ForceChangePasswordException as err:
+                raise PasswordChangeRequiredError(
+                    "Cognito requires a password change before sign-in"
+                ) from err
+            except WarrantException as err:
+                # e.g. TokenVerificationException from pycognito verifying
+                # the freshly issued tokens
+                raise EvnexAuthError(str(err)) from err
+            if isinstance(result, TokenSet):
+                await self._store_tokens(result)
+            return result
+
+    async def respond_to_challenge(
+        self, challenge: AuthChallenge, response: str
+    ) -> TokenSet | AuthChallenge:
+        """Answer an authentication challenge (e.g. with a 6-digit MFA code).
+
+        :raises InvalidChallengeResponseError: the code was rejected; the same
+            challenge may be retried with a new code
+        :raises ChallengeExpiredError: the challenge session lapsed; call
+            start_authentication() again
+        :raises EvnexAuthError: the challenge type is not supported
+        """
+
+        def _respond() -> TokenSet:
+            cognito = self._ensure_cognito()
+            cognito.username = challenge.username
+            mfa_tokens = {
+                "ChallengeName": challenge.name,
+                "Session": challenge.session,
+            }
+            if challenge.name == CHALLENGE_SOFTWARE_TOKEN_MFA:
+                cognito.respond_to_software_token_mfa_challenge(
+                    response.strip(), mfa_tokens=mfa_tokens
+                )
+            elif challenge.name == CHALLENGE_SMS_MFA:
+                cognito.respond_to_sms_mfa_challenge(
+                    response.strip(), mfa_tokens=mfa_tokens
+                )
+            else:
+                raise EvnexAuthError(
+                    f"Unsupported authentication challenge {challenge.name!r}"
+                )
+            return self._tokens_from_cognito(cognito)
+
+        async with self._lock:
+            try:
+                tokens = await asyncio.to_thread(_respond)
+            except botocore.exceptions.ClientError as err:
+                raise _map_challenge_error(err) from err
+            except TokenVerificationException as err:
+                raise EvnexAuthError(str(err)) from err
+            await self._store_tokens(tokens)
+            return tokens
+
+    async def get_access_token(self) -> str:
+        """Return a valid access token, refreshing the session if required.
+
+        :raises ReauthenticationRequiredError: no usable session exists
+        """
+        tokens = self._tokens
+        if tokens is None or tokens.access_token is None:
+            refreshed = await self.force_refresh(
+                stale_access_token=tokens.access_token if tokens else None
+            )
+            return self._require_access_token(refreshed)
+        if tokens.expires_at is not None:
+            now = datetime.now(tz=UTC)
+            if now >= tokens.expires_at - EXPIRY_SKEW:
+                refreshed = await self.force_refresh(
+                    stale_access_token=tokens.access_token
+                )
+                return self._require_access_token(refreshed)
+        return tokens.access_token
+
+    @staticmethod
+    def _require_access_token(tokens: TokenSet) -> str:
+        if tokens.access_token is None:
+            raise ReauthenticationRequiredError(
+                "The refreshed session did not include an access token"
+            )
+        return tokens.access_token
+
+    async def force_refresh(
+        self, *, stale_access_token: str | None = _ALWAYS_REFRESH
+    ) -> TokenSet:
+        """Obtain fresh tokens using the refresh token.
+
+        Single-flight: pass the access token that was rejected (possibly
+        None for a session that never had one) as stale_access_token, and
+        callers that lost the race return the already-rotated token set
+        without refreshing again. Omit it to refresh unconditionally.
+
+        :raises ReauthenticationRequiredError: no refresh token, or Cognito
+            rejected it
+        """
+        async with self._lock:
+            current = self._tokens
+            if (
+                current is not None
+                and stale_access_token is not _ALWAYS_REFRESH
+                and current.access_token != stale_access_token
+            ):
+                return current
+
+            if current is None or current.refresh_token is None:
+                raise ReauthenticationRequiredError(
+                    "No session tokens; interactive authentication is required"
+                )
+
+            def _renew() -> TokenSet:
+                cognito = self._ensure_cognito()
+                cognito.access_token = current.access_token
+                cognito.id_token = current.id_token
+                cognito.refresh_token = current.refresh_token
+                cognito.renew_access_token()
+                return self._tokens_from_cognito(cognito)
+
+            logger.debug("Refreshing session tokens")
+            try:
+                tokens = await asyncio.to_thread(_renew)
+            except botocore.exceptions.ClientError as err:
+                raise ReauthenticationRequiredError(_error_message(err)) from err
+            except WarrantException as err:
+                # The renewed tokens failed pycognito's verification; the
+                # session cannot be trusted. Network errors (requests/boto
+                # connection failures) deliberately propagate: they are
+                # transient and remain retryable.
+                raise ReauthenticationRequiredError(str(err)) from err
+            await self._store_tokens(tokens)
+            return tokens
+
+    def _ensure_cognito(self) -> Cognito:
+        """Build the pycognito client on first use.
+
+        Only call from a worker-thread closure with the lock held:
+        construction performs blocking I/O, and the returned instance is
+        mutable shared state.
+        """
+        if self._cognito is None:
+            self._cognito = Cognito(
+                user_pool_id=self._config.EVNEX_COGNITO_USER_POOL_ID,
+                client_id=self._config.EVNEX_COGNITO_CLIENT_ID,
+                username=None,
+            )
+        return self._cognito
+
+    def _tokens_from_cognito(self, cognito: Cognito) -> TokenSet:
+        return TokenSet(
+            access_token=cognito.access_token,
+            id_token=cognito.id_token,
+            # Cognito omits the refresh token from renewals unless rotation
+            # is enabled; carry the current one forward
+            refresh_token=cognito.refresh_token
+            or (self._tokens.refresh_token if self._tokens else None),
+        )
+
+    async def _store_tokens(self, tokens: TokenSet) -> None:
+        """Persist a newly issued token set, then make it the current one.
+
+        Ordering matters: on_token_update completes before the assignment
+        that makes the tokens visible to other tasks (including
+        get_access_token's lock-free fast path), so a token set can never be
+        used for a request before the application has persisted it.
+
+        The callback's failures are logged and swallowed on purpose: the
+        tokens are valid regardless, and a broken store must not take API
+        access down with it. The application can always re-read .tokens.
+        """
+        assert self._lock.locked(), "_store_tokens requires the lock"
+        if self._on_token_update is not None:
+            try:
+                await self._on_token_update(tokens)
+            except Exception:
+                logger.exception("on_token_update callback failed")
+        self._tokens = tokens
+
+
+class EvnexHttpxAuth(httpx.Auth):
+    """httpx auth flow: inject the access token; on 401 refresh and resend once.
+
+    A 401 means the server rejected the request before executing it, so the
+    single resend is safe even for command endpoints.
+    """
+
+    def __init__(self, auth: EvnexAuth) -> None:
+        self._auth = auth
+
+    async def async_auth_flow(self, request: httpx.Request):
+        token = await self._auth.get_access_token()
+        request.headers["Authorization"] = token
+        response = yield request
+        if response.status_code == 401:
+            await self._auth.force_refresh(stale_access_token=token)
+            request.headers["Authorization"] = await self._auth.get_access_token()
+            yield request
+
+    def sync_auth_flow(self, request: httpx.Request):
+        raise RuntimeError("EvnexHttpxAuth only supports async clients")
+
+
+def _error_message(err: botocore.exceptions.ClientError) -> str:
+    return str(err.response.get("Error", {}).get("Message", err))
+
+
+def _map_challenge_error(err: botocore.exceptions.ClientError) -> EvnexAuthError:
+    code = err.response.get("Error", {}).get("Code", "")
+    message = _error_message(err)
+    if code == "CodeMismatchException":
+        return InvalidChallengeResponseError(message)
+    if code in ("ExpiredCodeException", "NotAuthorizedException"):
+        # Cognito reports a lapsed challenge session as NotAuthorized
+        return ChallengeExpiredError(message)
+    return EvnexAuthError(message)

--- a/evnex/config.py
+++ b/evnex/config.py
@@ -1,0 +1,8 @@
+from pydantic_settings import BaseSettings
+
+
+class EvnexConfig(BaseSettings):
+    EVNEX_BASE_URL: str = "https://client-api.evnex.io"
+    EVNEX_COGNITO_USER_POOL_ID: str = "ap-southeast-2_zWnqo6ASv"
+    EVNEX_COGNITO_CLIENT_ID: str = "rol3lsv2vg41783550i18r7vi"
+    EVNEX_ORG_ID: str | None = None

--- a/evnex/errors.py
+++ b/evnex/errors.py
@@ -1,10 +1,46 @@
-class NotAuthorizedException(ValueError):
-    pass
+"""Typed errors raised by the EVNEX client.
+
+All authentication problems derive from EvnexAuthError; catch that to
+handle "the session is not usable" generically, or a subclass to react to
+a specific condition.
+"""
+
+import warnings
 
 
-class TokenRefreshedError(Exception):
-    """A 401 response triggered a successful token refresh.
+class EvnexAuthError(ValueError):
+    """Base for authentication and session lifecycle errors."""
 
-    Internal to the retry policy: the request is retried with the fresh
-    tokens, and if it keeps failing the caller sees NotAuthorizedException.
-    """
+
+class InvalidCredentialsError(EvnexAuthError):
+    """The username or password was rejected."""
+
+
+class ReauthenticationRequiredError(EvnexAuthError):
+    """The session cannot be renewed; interactive authentication is needed."""
+
+
+class ChallengeExpiredError(EvnexAuthError):
+    """The short-lived challenge session lapsed; restart authentication."""
+
+
+class PasswordChangeRequiredError(EvnexAuthError):
+    """A new password must be set before this account can sign in."""
+
+
+class InvalidChallengeResponseError(EvnexAuthError):
+    """The challenge response (e.g. MFA code) was rejected; retry is possible."""
+
+
+def __getattr__(name: str):
+    # Deprecated alias, served dynamically so importing it warns.
+    # Removed in 0.8.0.
+    if name == "NotAuthorizedException":
+        warnings.warn(
+            "NotAuthorizedException is deprecated and will be removed in "
+            "evnex 0.8.0; catch EvnexAuthError instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return EvnexAuthError
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/examples/configure_charger_load_management.py
+++ b/examples/configure_charger_load_management.py
@@ -1,25 +1,19 @@
 import asyncio
 import logging
-
-from pydantic import SecretStr
-from pydantic_settings import BaseSettings
+import os
 
 from evnex.api import Evnex
+from evnex.auth import EvnexAuth
 
 logging.basicConfig(level=logging.WARNING)
 
 
-class EvnexAuthDetails(BaseSettings):
-    EVNEX_CLIENT_USERNAME: str
-    EVNEX_CLIENT_PASSWORD: SecretStr
-
-
 async def main():
-    creds = EvnexAuthDetails()
-    evnex = Evnex(
-        username=creds.EVNEX_CLIENT_USERNAME,
-        password=creds.EVNEX_CLIENT_PASSWORD.get_secret_value(),
+    auth = EvnexAuth()
+    await auth.start_authentication(
+        os.environ["EVNEX_CLIENT_USERNAME"], os.environ["EVNEX_CLIENT_PASSWORD"]
     )
+    evnex = Evnex(auth=auth)
 
     user_data = await evnex.get_user_detail()
     for org in user_data.organisations:

--- a/examples/get_charge_point_detail.py
+++ b/examples/get_charge_point_detail.py
@@ -1,26 +1,21 @@
 import asyncio
 import logging
+import os
 
 from httpx import HTTPStatusError
-from pydantic import SecretStr
-from pydantic_settings import BaseSettings
 
 from evnex.api import Evnex
+from evnex.auth import EvnexAuth
 
 logging.basicConfig(level=logging.WARNING)
 
 
-class EvnexAuthDetails(BaseSettings):
-    EVNEX_CLIENT_USERNAME: str
-    EVNEX_CLIENT_PASSWORD: SecretStr
-
-
 async def main():
-    creds = EvnexAuthDetails()
-    evnex = Evnex(
-        username=creds.EVNEX_CLIENT_USERNAME,
-        password=creds.EVNEX_CLIENT_PASSWORD.get_secret_value(),
+    auth = EvnexAuth()
+    await auth.start_authentication(
+        os.environ["EVNEX_CLIENT_USERNAME"], os.environ["EVNEX_CLIENT_PASSWORD"]
     )
+    evnex = Evnex(auth=auth)
 
     user_data = await evnex.get_user_detail()
 

--- a/examples/get_org_insights.py
+++ b/examples/get_org_insights.py
@@ -1,22 +1,16 @@
 import asyncio
-
-from pydantic import SecretStr
-from pydantic_settings import BaseSettings
+import os
 
 from evnex.api import Evnex
-
-
-class EvnexAuthDetails(BaseSettings):
-    EVNEX_CLIENT_USERNAME: str
-    EVNEX_CLIENT_PASSWORD: SecretStr
+from evnex.auth import EvnexAuth
 
 
 async def main():
-    creds = EvnexAuthDetails()
-    evnex = Evnex(
-        username=creds.EVNEX_CLIENT_USERNAME,
-        password=creds.EVNEX_CLIENT_PASSWORD.get_secret_value(),
+    auth = EvnexAuth()
+    await auth.start_authentication(
+        os.environ["EVNEX_CLIENT_USERNAME"], os.environ["EVNEX_CLIENT_PASSWORD"]
     )
+    evnex = Evnex(auth=auth)
 
     user_data = await evnex.get_user_detail()
 

--- a/examples/get_token.py
+++ b/examples/get_token.py
@@ -1,59 +1,46 @@
 #!/usr/bin/env python3
 """
-Example script to get a token from AWS cognito. Supports MFA authentication.
+Example: sign in (with MFA if enabled) and print the session tokens.
 """
 
 import asyncio
 import logging
-
-from pycognito.exceptions import (
-    SMSMFAChallengeException,
-    SoftwareTokenMFAChallengeException,
-)
-from pydantic import SecretStr
-from pydantic_settings import BaseSettings, SettingsConfigDict
+import os
 
 from evnex.api import Evnex
+from evnex.auth import AuthChallenge, EvnexAuth, TokenSet
 
 
-class EvnexAuthDetails(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="EVNEX_")
-
-    CLIENT_USERNAME: str
-    CLIENT_PASSWORD: SecretStr
-    ID_TOKEN: str | None = None
-    REFRESH_TOKEN: str | None = None
-    ACCESS_TOKEN: str | None = None
+async def save_tokens(tokens: TokenSet) -> None:
+    # A real application would persist these atomically
+    print("New tokens issued; persist them for next time")
 
 
 async def main():
-    creds = EvnexAuthDetails()
-    evnex = Evnex(
-        username=creds.CLIENT_USERNAME,
-        password=creds.CLIENT_PASSWORD.get_secret_value(),
-        id_token=creds.ID_TOKEN,
-        refresh_token=creds.REFRESH_TOKEN,
-        access_token=creds.ACCESS_TOKEN,
-    )
+    tokens = None
+    if os.environ.get("EVNEX_ACCESS_TOKEN") or os.environ.get("EVNEX_REFRESH_TOKEN"):
+        tokens = TokenSet(
+            access_token=os.environ.get("EVNEX_ACCESS_TOKEN"),
+            refresh_token=os.environ.get("EVNEX_REFRESH_TOKEN"),
+        )
 
-    if not creds.ACCESS_TOKEN and not creds.REFRESH_TOKEN:
-        try:
-            evnex.authenticate()
+    auth = EvnexAuth(tokens=tokens, on_token_update=save_tokens)
 
-        except SMSMFAChallengeException:
-            code = input("Enter the 6-digit code you received by SMS: ")
-            evnex.respond_to_mfa_challenge(code, "SMS")
+    if tokens is None:
+        result = await auth.start_authentication(
+            os.environ["EVNEX_CLIENT_USERNAME"], os.environ["EVNEX_CLIENT_PASSWORD"]
+        )
+        while isinstance(result, AuthChallenge):
+            code = input(f"Enter the code for challenge {result.name}: ")
+            result = await auth.respond_to_challenge(result, code)
 
-        except SoftwareTokenMFAChallengeException:
-            code = input("Enter the 6-digit code from your authenticator application: ")
-            evnex.respond_to_mfa_challenge(code, "TOTP")
+    evnex = Evnex(auth=auth)
+    user = await evnex.get_user_detail()
+    print("User Name:", user.name or user.email)
 
-    user_details = await evnex.get_user_detail()
-    print("User Name:", user_details.name)
-
-    print("Access Token: ", evnex.access_token)
-    print("Refresh Token: ", evnex.refresh_token)
-    print("ID Token: ", evnex.id_token)
+    print("Access Token: ", auth.tokens.access_token)
+    print("Refresh Token: ", auth.tokens.refresh_token)
+    print("Expires At: ", auth.tokens.expires_at)
 
 
 if __name__ == "__main__":

--- a/examples/set_charge_point_availability.py
+++ b/examples/set_charge_point_availability.py
@@ -1,27 +1,19 @@
 import asyncio
 import logging
-
-try:
-    from pydantic.v1 import BaseSettings, SecretStr
-except ImportError:
-    from pydantic import BaseSettings, SecretStr
+import os
 
 from evnex.api import Evnex
+from evnex.auth import EvnexAuth
 
 logging.basicConfig(level=logging.INFO)
 
 
-class EvnexAuthDetails(BaseSettings):
-    EVNEX_CLIENT_USERNAME: str
-    EVNEX_CLIENT_PASSWORD: SecretStr
-
-
 async def main():
-    creds = EvnexAuthDetails()
-    evnex = Evnex(
-        username=creds.EVNEX_CLIENT_USERNAME,
-        password=creds.EVNEX_CLIENT_PASSWORD.get_secret_value(),
+    auth = EvnexAuth()
+    await auth.start_authentication(
+        os.environ["EVNEX_CLIENT_USERNAME"], os.environ["EVNEX_CLIENT_PASSWORD"]
     )
+    evnex = Evnex(auth=auth)
 
     user_data = await evnex.get_user_detail()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evnex"
-version = "0.6.1"
+version = "0.7.0"
 description = "A Python wrapper for the EVNEX Cloud API"
 authors = [{ name = "Brian Thorne", email = "brian@hardbyte.nz" }]
 readme = "README.md"
@@ -15,6 +15,7 @@ dependencies = [
     "boto3>=1.26,<2.0",
     "pydantic>2.0.0,<3.0.0",
     "tenacity>=8.1,<10.0",
+    "pyjwt>=2.8,<3.0",
     "pydantic-settings>=2.2,<3.0",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,24 @@
 import time
+from datetime import UTC, datetime, timedelta
 from unittest.mock import DEFAULT, MagicMock
 
+import jwt
 import pytest
 from blockbuster import blockbuster_ctx
 from tenacity import wait_none
 
 from evnex.api import Evnex
+from evnex.auth import EvnexAuth, TokenSet
+
+
+def make_jwt(expires_in: timedelta = timedelta(hours=24)) -> str:
+    """A structurally valid (unverified) access token with an exp claim."""
+    exp = datetime.now(tz=UTC) + expires_in
+    return jwt.encode(
+        {"exp": int(exp.timestamp())},
+        key="test-key-long-enough-for-hs256-minimum!",
+        algorithm="HS256",
+    )
 
 
 class FakeCognito:
@@ -13,31 +26,24 @@ class FakeCognito:
 
     Each method briefly sleeps, mimicking pycognito's blocking network I/O,
     so blockbuster fails any test where one runs on the event loop instead
-    of in a worker thread.
+    of in a worker thread. Construction also blocks, mimicking boto3 client
+    setup.
     """
 
-    def __init__(
-        self,
-        user_pool_id=None,
-        client_id=None,
-        username=None,
-        id_token=None,
-        refresh_token=None,
-        access_token=None,
-    ):
+    def __init__(self, user_pool_id=None, client_id=None, username=None, **kwargs):
+        time.sleep(0.001)
         self.username = username
-        self.id_token = id_token
-        self.refresh_token = refresh_token
-        self.access_token = access_token
-        self.mfa_tokens = None
+        self.id_token = None
+        self.refresh_token = None
+        self.access_token = None
         self._token_serial = 0
         self.authenticate = MagicMock(side_effect=self._issue_tokens)
-        self.check_token = MagicMock(return_value=False, side_effect=self._block)
         self.renew_access_token = MagicMock(side_effect=self._rotate_tokens)
-        self.verify_tokens = MagicMock(side_effect=self._block)
-        self.respond_to_sms_mfa_challenge = MagicMock(side_effect=self._block)
         self.respond_to_software_token_mfa_challenge = MagicMock(
-            side_effect=self._block
+            side_effect=lambda code, mfa_tokens=None: self._issue_tokens()
+        )
+        self.respond_to_sms_mfa_challenge = MagicMock(
+            side_effect=lambda code, mfa_tokens=None: self._issue_tokens()
         )
 
     @staticmethod
@@ -47,8 +53,9 @@ class FakeCognito:
 
     def _issue_tokens(self, password=None):
         self._block()
-        self.access_token = "access-0"
-        self.id_token = "id-0"
+        self._token_serial += 1
+        self.access_token = f"access-{self._token_serial}"
+        self.id_token = f"id-{self._token_serial}"
         self.refresh_token = "refresh-0"
 
     def _rotate_tokens(self):
@@ -56,6 +63,9 @@ class FakeCognito:
         self._token_serial += 1
         self.access_token = f"access-{self._token_serial}"
         self.id_token = f"id-{self._token_serial}"
+        # Cognito renewals do not return a refresh token unless rotation
+        # is enabled on the pool
+        self.refresh_token = None
 
 
 @pytest.fixture(autouse=True)
@@ -66,27 +76,41 @@ def detect_blocking_calls():
 
 @pytest.fixture(autouse=True)
 def offline(monkeypatch):
-    monkeypatch.setattr("evnex.api.Cognito", FakeCognito)
+    monkeypatch.setattr("evnex.auth.Cognito", FakeCognito)
     monkeypatch.setattr(Evnex.get_user_detail.retry, "wait", wait_none())
 
 
 @pytest.fixture
-def client():
-    return Evnex(username="user@example.com", password="hunter2")
+def token_updates():
+    """Records every TokenSet published via on_token_update."""
+    return []
 
 
 @pytest.fixture
-def authenticated_client(client):
-    client.cognito._issue_tokens()
-    return client
+def auth(token_updates):
+    async def record(tokens: TokenSet) -> None:
+        token_updates.append(tokens)
+
+    return EvnexAuth(on_token_update=record)
 
 
 @pytest.fixture
-def resumed_client():
-    return Evnex(
-        username="user@example.com",
-        password="hunter2",
-        id_token="id-0",
-        access_token="access-0",
-        refresh_token="refresh-0",
+def resumed_auth(token_updates):
+    """An EvnexAuth resumed from persisted tokens (no credentials)."""
+
+    async def record(tokens: TokenSet) -> None:
+        token_updates.append(tokens)
+
+    return EvnexAuth(
+        tokens=TokenSet(
+            access_token="access-0",
+            id_token="id-0",
+            refresh_token="refresh-0",
+        ),
+        on_token_update=record,
     )
+
+
+@pytest.fixture
+def client(resumed_auth):
+    return Evnex(auth=resumed_auth)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,4 @@
-"""Tests for authentication, token refresh, MFA and retry behaviour.
+"""Tests for the EvnexAuth token lifecycle and transport-level 401 recovery.
 
 Cognito is replaced with an offline fake (see conftest.FakeCognito); HTTP
 calls are mocked with respx; blockbuster fails any test that runs blocking
@@ -6,18 +6,30 @@ I/O on the event loop.
 """
 
 import asyncio
+from datetime import timedelta
 
 import botocore.exceptions
 import httpx
 import pytest
 import respx
-from pycognito.exceptions import (
-    SoftwareTokenMFAChallengeException,
-    TokenVerificationException,
-)
+from pycognito.exceptions import SoftwareTokenMFAChallengeException
 
 from evnex.api import Evnex
-from evnex.errors import NotAuthorizedException
+from evnex.auth import (
+    CHALLENGE_SOFTWARE_TOKEN_MFA,
+    AuthChallenge,
+    EvnexAuth,
+    TokenSet,
+)
+from evnex.errors import (
+    ChallengeExpiredError,
+    EvnexAuthError,
+    InvalidChallengeResponseError,
+    InvalidCredentialsError,
+    ReauthenticationRequiredError,
+)
+
+from .conftest import make_jwt
 
 USER_URL = "https://client-api.evnex.io/v2/apps/user"
 
@@ -28,190 +40,245 @@ USER_PAYLOAD = {
         "updatedDate": "2022-01-01T00:00:00Z",
         "name": "Test User",
         "email": "user@example.com",
-        "organisations": [
-            {
-                "id": "org-1",
-                "isDefault": True,
-                "role": 1,
-                "createdDate": "2022-01-01T00:00:00Z",
-                "name": "Home",
-                "slug": "home",
-                "tier": 1,
-                "updatedDate": "2022-01-01T00:00:00Z",
-            }
-        ],
+        "organisations": [],
     }
 }
 
 
-class TestFirstUseAuthentication:
-    async def test_first_call_authenticates_automatically(self, client):
+def client_error(code: str, message: str = "nope") -> botocore.exceptions.ClientError:
+    return botocore.exceptions.ClientError(
+        {"Error": {"Code": code, "Message": message}}, "SomeOperation"
+    )
+
+
+def mfa_challenge_exception() -> SoftwareTokenMFAChallengeException:
+    return SoftwareTokenMFAChallengeException(
+        "Do Software Token MFA",
+        {
+            "ChallengeName": CHALLENGE_SOFTWARE_TOKEN_MFA,
+            "Session": "opaque-session",
+            "ChallengeParameters": {"FRIENDLY_DEVICE_NAME": "My TOTP device"},
+        },
+    )
+
+
+class TestTokenSet:
+    def test_round_trips_through_dict(self):
+        tokens = TokenSet(
+            access_token=make_jwt(), id_token="id", refresh_token="refresh"
+        )
+        restored = TokenSet.from_dict(tokens.to_dict())
+        assert restored == tokens
+
+    def test_expiry_derived_from_jwt_when_missing(self):
+        data = {"access_token": make_jwt(timedelta(hours=1)), "refresh_token": "r"}
+        tokens = TokenSet.from_dict(data)
+        assert tokens.expires_at is not None
+
+    def test_repr_redacts_tokens(self):
+        tokens = TokenSet(access_token="secret-access", refresh_token="secret-refresh")
+        assert "secret" not in repr(tokens)
+
+
+class TestAuthChallenge:
+    def test_round_trips_through_dict(self):
+        challenge = AuthChallenge(
+            name=CHALLENGE_SOFTWARE_TOKEN_MFA,
+            session="s",
+            username="user@example.com",
+            parameters={"FRIENDLY_DEVICE_NAME": "phone"},
+        )
+        assert AuthChallenge.from_dict(challenge.to_dict()) == challenge
+
+
+class TestInteractiveAuthentication:
+    async def test_password_only_success(self, auth, token_updates):
+        result = await auth.start_authentication("user@example.com", "hunter2")
+
+        assert isinstance(result, TokenSet)
+        assert auth.tokens is result
+        assert token_updates == [result]
+
+    async def test_mfa_challenge_returned(self, auth, token_updates):
+        # First call builds the fake cognito so the side effect can be set
+        await auth.start_authentication("user@example.com", "hunter2")
+        auth._cognito.authenticate.side_effect = mfa_challenge_exception()
+        auth._tokens = None
+        token_updates.clear()
+
+        challenge = await auth.start_authentication("user@example.com", "hunter2")
+
+        assert isinstance(challenge, AuthChallenge)
+        assert challenge.name == CHALLENGE_SOFTWARE_TOKEN_MFA
+        assert challenge.username == "user@example.com"
+        assert challenge.parameters["FRIENDLY_DEVICE_NAME"] == "My TOTP device"
+        assert auth.tokens is None
+        assert token_updates == []
+
+    async def test_challenge_response_issues_tokens(self, auth, token_updates):
+        challenge = AuthChallenge(
+            name=CHALLENGE_SOFTWARE_TOKEN_MFA,
+            session="opaque-session",
+            username="user@example.com",
+        )
+        result = await auth.respond_to_challenge(challenge, "123456")
+
+        assert isinstance(result, TokenSet)
+        assert auth.tokens is result
+        assert token_updates == [result]
+        auth._cognito.respond_to_software_token_mfa_challenge.assert_called_once_with(
+            "123456",
+            mfa_tokens={
+                "ChallengeName": CHALLENGE_SOFTWARE_TOKEN_MFA,
+                "Session": "opaque-session",
+            },
+        )
+
+    async def test_wrong_code_raises_invalid_response(self, auth):
+        challenge = AuthChallenge(
+            name=CHALLENGE_SOFTWARE_TOKEN_MFA, session="s", username="u"
+        )
+        await auth.start_authentication("u", "p")  # builds the fake cognito
+        auth._cognito.respond_to_software_token_mfa_challenge.side_effect = (
+            client_error("CodeMismatchException")
+        )
+
+        with pytest.raises(InvalidChallengeResponseError):
+            await auth.respond_to_challenge(challenge, "000000")
+
+    async def test_expired_session_raises_challenge_expired(self, auth):
+        challenge = AuthChallenge(
+            name=CHALLENGE_SOFTWARE_TOKEN_MFA, session="s", username="u"
+        )
+        await auth.start_authentication("u", "p")
+        auth._cognito.respond_to_software_token_mfa_challenge.side_effect = (
+            client_error("NotAuthorizedException", "Invalid session for the user")
+        )
+
+        with pytest.raises(ChallengeExpiredError):
+            await auth.respond_to_challenge(challenge, "123456")
+
+    async def test_unsupported_challenge_type(self, auth):
+        challenge = AuthChallenge(
+            name="NEW_PASSWORD_REQUIRED", session="s", username="u"
+        )
+
+        with pytest.raises(EvnexAuthError, match="NEW_PASSWORD_REQUIRED"):
+            await auth.respond_to_challenge(challenge, "irrelevant")
+
+    async def test_invalid_credentials(self, auth):
+        await auth.start_authentication("u", "p")
+        auth._cognito.authenticate.side_effect = client_error(
+            "NotAuthorizedException", "Incorrect username or password."
+        )
+
+        with pytest.raises(InvalidCredentialsError):
+            await auth.start_authentication("u", "wrong")
+
+    async def test_deprecated_not_authorized_exception_alias(self):
+        with pytest.warns(DeprecationWarning, match="NotAuthorizedException"):
+            from evnex.errors import NotAuthorizedException
+        # Existing handlers keep working: the alias is the new base class,
+        # which remains a ValueError like the original
+        assert NotAuthorizedException is EvnexAuthError
+        assert issubclass(InvalidCredentialsError, ValueError)
+
+
+class TestTokenLifecycle:
+    async def test_resume_needs_no_credentials(self, resumed_auth):
+        token = await resumed_auth.get_access_token()
+        assert token == "access-0"
+
+    async def test_no_session_raises_reauthentication_required(self, auth):
+        with pytest.raises(ReauthenticationRequiredError):
+            await auth.get_access_token()
+
+    async def test_expired_token_refreshed_proactively(self):
+        expired = make_jwt(timedelta(seconds=-60))
+        auth = EvnexAuth(
+            tokens=TokenSet(access_token=expired, refresh_token="refresh-0")
+        )
+        token = await auth.get_access_token()
+
+        assert token == "access-1"
+        assert auth.tokens.refresh_token == "refresh-0"  # carried forward
+
+    async def test_force_refresh_single_flight(self, resumed_auth):
+        results = await asyncio.gather(
+            resumed_auth.force_refresh(stale_access_token="access-0"),
+            resumed_auth.force_refresh(stale_access_token="access-0"),
+        )
+
+        assert results[0] == results[1]
+        resumed_auth._cognito.renew_access_token.assert_called_once()
+
+    async def test_refresh_without_refresh_token(self):
+        auth = EvnexAuth(tokens=TokenSet(access_token="access-0"))
+        with pytest.raises(ReauthenticationRequiredError):
+            await auth.force_refresh(stale_access_token="access-0")
+
+    async def test_callback_failure_does_not_break_auth(self, caplog):
+        async def failing_callback(tokens: TokenSet) -> None:
+            raise RuntimeError("disk full")
+
+        auth = EvnexAuth(on_token_update=failing_callback)
+        result = await auth.start_authentication("u", "p")
+
+        assert isinstance(result, TokenSet)
+        assert auth.tokens is result
+        assert "on_token_update callback failed" in caplog.text
+
+
+class TestTransport:
+    async def test_request_carries_access_token(self, client):
         with respx.mock:
-            respx.get(USER_URL).mock(
+            route = respx.get(USER_URL).mock(
                 return_value=httpx.Response(200, json=USER_PAYLOAD)
             )
             user = await client.get_user_detail()
 
         assert user.name == "Test User"
-        client.cognito.authenticate.assert_called_once()
+        assert route.calls[0].request.headers["Authorization"] == "access-0"
 
-    async def test_auth_failure_raises_immediately(self, client):
-        client.cognito.authenticate.side_effect = botocore.exceptions.ClientError(
-            {"Error": {"Code": "NotAuthorizedException", "Message": "Bad creds"}},
-            "InitiateAuth",
-        )
-
-        with pytest.raises(NotAuthorizedException):
-            await client.get_user_detail()
-        # Never retried: auth errors would lock accounts and can't self-heal
-        client.cognito.authenticate.assert_called_once()
-
-    async def test_mfa_challenge_propagates_without_retry(self, client):
-        client.cognito.authenticate.side_effect = SoftwareTokenMFAChallengeException(
-            "MFA challenge", {"ChallengeName": "SOFTWARE_TOKEN_MFA", "Session": "s"}
-        )
-
-        with pytest.raises(SoftwareTokenMFAChallengeException):
-            await client.get_user_detail()
-        client.cognito.authenticate.assert_called_once()
-
-    async def test_concurrent_first_calls_authenticate_once(self, client):
-        with respx.mock:
-            respx.get(USER_URL).mock(
-                return_value=httpx.Response(200, json=USER_PAYLOAD)
-            )
-            await asyncio.gather(client.get_user_detail(), client.get_user_detail())
-
-        client.cognito.authenticate.assert_called_once()
-
-
-class TestTokenRefresh:
-    async def test_no_proactive_checks_on_happy_path(self, authenticated_client):
-        with respx.mock:
-            respx.get(USER_URL).mock(
-                return_value=httpx.Response(200, json=USER_PAYLOAD)
-            )
-            await authenticated_client.get_user_detail()
-            await authenticated_client.get_user_detail()
-
-        # Expiry is handled reactively via 401 responses, so successful
-        # requests never touch Cognito
-        authenticated_client.cognito.check_token.assert_not_called()
-        authenticated_client.cognito.renew_access_token.assert_not_called()
-
-    async def test_refresh_failure_wrapped_and_not_retried(self, authenticated_client):
-        authenticated_client.cognito.renew_access_token.side_effect = (
-            botocore.exceptions.ClientError(
-                {
-                    "Error": {
-                        "Code": "NotAuthorized",
-                        "Message": "Refresh token expired",
-                    }
-                },
-                "InitiateAuth",
-            )
-        )
+    async def test_401_refreshes_and_resends_once(self, client, token_updates):
+        def respond(request):
+            if request.headers["Authorization"] == "access-0":
+                return httpx.Response(401)
+            return httpx.Response(200, json=USER_PAYLOAD)
 
         with respx.mock:
-            route = respx.get(USER_URL).mock(return_value=httpx.Response(401))
-            with pytest.raises(NotAuthorizedException):
-                await authenticated_client.get_user_detail()
-
-        assert route.call_count == 1
-        authenticated_client.cognito.renew_access_token.assert_called_once()
-
-    async def test_refresh_token_only_resumption(self):
-        client = Evnex(
-            username="user@example.com", password="hunter2", refresh_token="refresh-0"
-        )
-
-        def do_renew():
-            client.cognito.access_token = "access-1"
-            client.cognito.id_token = "id-1"
-
-        client.cognito.renew_access_token.side_effect = do_renew
-
-        with respx.mock:
-            respx.get(USER_URL).mock(
-                return_value=httpx.Response(200, json=USER_PAYLOAD)
-            )
+            route = respx.get(USER_URL).mock(side_effect=respond)
             user = await client.get_user_detail()
-
-        assert user.name == "Test User"
-        client.cognito.renew_access_token.assert_called_once()
-        client.cognito.authenticate.assert_not_called()
-
-
-class TestResumedTokenVerification:
-    async def test_resumed_tokens_verified_once_on_first_use(self, resumed_client):
-        with respx.mock:
-            respx.get(USER_URL).mock(
-                return_value=httpx.Response(200, json=USER_PAYLOAD)
-            )
-            await resumed_client.get_user_detail()
-            await resumed_client.get_user_detail()
-
-        resumed_client.cognito.verify_tokens.assert_called_once()
-
-    async def test_invalid_resumed_tokens_raise_not_authorized(self, resumed_client):
-        resumed_client.cognito.verify_tokens.side_effect = TokenVerificationException(
-            "bad signature"
-        )
-
-        with pytest.raises(NotAuthorizedException):
-            await resumed_client.get_user_detail()
-
-
-class TestUnauthorizedResponses:
-    async def test_401_refreshes_and_retries_request(self, authenticated_client):
-        with respx.mock:
-            route = respx.get(USER_URL)
-            route.side_effect = [
-                httpx.Response(401),
-                httpx.Response(200, json=USER_PAYLOAD),
-            ]
-            user = await authenticated_client.get_user_detail()
 
         assert user.name == "Test User"
         assert route.call_count == 2
-        authenticated_client.cognito.renew_access_token.assert_called_once()
+        assert route.calls[1].request.headers["Authorization"] == "access-1"
+        # The rotated tokens were published before the resend completed
+        assert token_updates and token_updates[0].access_token == "access-1"
 
-    async def test_401_reauthenticates_without_refresh_token(self, client):
-        # Sessions without a refresh token fall back to password auth
-        client.cognito.access_token = "access-0"
-        client.cognito.id_token = "id-0"
-
-        with respx.mock:
-            route = respx.get(USER_URL)
-            route.side_effect = [
-                httpx.Response(401),
-                httpx.Response(200, json=USER_PAYLOAD),
-            ]
-            user = await client.get_user_detail()
-
-        assert user.name == "Test User"
-        client.cognito.authenticate.assert_called_once()
-        client.cognito.renew_access_token.assert_not_called()
-
-    async def test_persistent_401_despite_renewals_exhausts_retries(
-        self, authenticated_client
-    ):
+    async def test_persistent_401_not_retried_by_tenacity(self, client):
         with respx.mock:
             route = respx.get(USER_URL).mock(return_value=httpx.Response(401))
-            with pytest.raises(NotAuthorizedException):
-                await authenticated_client.get_user_detail()
+            with pytest.raises(ReauthenticationRequiredError):
+                await client.get_user_detail()
 
-        # Bounded by stop_after_attempt(5), not an endless refresh loop
-        assert route.call_count == 5
+        # One original request + exactly one auth-flow resend; the generic
+        # retry policy must not multiply auth recovery
+        assert route.call_count == 2
 
-    async def test_concurrent_401s_refresh_once(self, authenticated_client):
-        # Both coroutines fail with the same stale token; only the first
-        # holder of the lock refreshes, the other retries with new tokens
-        calls = 0
+    async def test_no_tokens_fails_before_any_request(self, auth):
+        client = Evnex(auth=auth)
+        with respx.mock:
+            route = respx.get(USER_URL).mock(
+                return_value=httpx.Response(200, json=USER_PAYLOAD)
+            )
+            with pytest.raises(ReauthenticationRequiredError):
+                await client.get_user_detail()
 
+        assert route.call_count == 0
+
+    async def test_concurrent_401s_refresh_once(self, client):
         def respond(request):
-            nonlocal calls
-            calls += 1
             if request.headers["Authorization"] == "access-0":
                 return httpx.Response(401)
             return httpx.Response(200, json=USER_PAYLOAD)
@@ -219,31 +286,170 @@ class TestUnauthorizedResponses:
         with respx.mock:
             respx.get(USER_URL).mock(side_effect=respond)
             users = await asyncio.gather(
-                authenticated_client.get_user_detail(),
-                authenticated_client.get_user_detail(),
+                client.get_user_detail(), client.get_user_detail()
             )
 
         assert all(user.name == "Test User" for user in users)
-        authenticated_client.cognito.renew_access_token.assert_called_once()
+        client.auth._cognito.renew_access_token.assert_called_once()
 
 
-class TestMFAChallengeResponse:
-    def test_invalid_mode_raises_value_error(self, client):
-        with pytest.raises(ValueError, match="Unknown MFA mode"):
-            client.respond_to_mfa_challenge("123456", "sms")
+class TestTokenSetResumption:
+    """Refresh-token-only resumption, persistence ordering, retry surfaces."""
 
-    def test_totp_mode_delegates_with_mfa_tokens(self, client):
-        client.respond_to_mfa_challenge("123456", "TOTP", mfa_tokens={"Session": "s"})
-        client.cognito.respond_to_software_token_mfa_challenge.assert_called_once_with(
-            "123456", mfa_tokens={"Session": "s"}
+    async def test_refresh_token_only_token_set(self):
+        # Constructible without an access token, including via from_dict
+        tokens = TokenSet(refresh_token="refresh-0")
+        assert tokens.access_token is None
+        assert TokenSet.from_dict({"refresh_token": "refresh-0"}) == tokens
+
+        auth = EvnexAuth(tokens=tokens)
+        assert await auth.get_access_token() == "access-1"
+
+    async def test_refresh_only_resume_makes_no_wasted_request(self):
+        auth = EvnexAuth(tokens=TokenSet(refresh_token="refresh-0"))
+        client = Evnex(auth=auth)
+
+        with respx.mock:
+            route = respx.get(USER_URL).mock(
+                return_value=httpx.Response(200, json=USER_PAYLOAD)
+            )
+            await client.get_user_detail()
+
+        # The refresh happened before the request, not via a 401 round-trip
+        assert route.call_count == 1
+        assert route.calls[0].request.headers["Authorization"] == "access-1"
+
+    async def test_concurrent_refresh_only_startup_single_flight(self):
+        auth = EvnexAuth(tokens=TokenSet(refresh_token="refresh-0"))
+        client = Evnex(auth=auth)
+
+        with respx.mock:
+            respx.get(USER_URL).mock(
+                return_value=httpx.Response(200, json=USER_PAYLOAD)
+            )
+            await asyncio.gather(client.get_user_detail(), client.get_user_detail())
+
+        auth._cognito.renew_access_token.assert_called_once()
+
+    async def test_tokens_published_only_after_persistence(self):
+        gate = asyncio.Event()
+        observed_during_persist = []
+
+        async def slow_save(tokens: TokenSet) -> None:
+            observed_during_persist.append(auth.tokens)
+            await gate.wait()
+
+        auth = EvnexAuth(
+            tokens=TokenSet(refresh_token="refresh-0"), on_token_update=slow_save
+        )
+        refresh = asyncio.create_task(auth.force_refresh())
+        while not observed_during_persist:
+            await asyncio.sleep(0)
+
+        # Mid-persistence, other tasks must still see the old token set
+        assert observed_during_persist[0] is not None
+        assert observed_during_persist[0].access_token is None
+        assert auth.tokens.access_token is None
+
+        gate.set()
+        new_tokens = await refresh
+        assert auth.tokens is new_tokens
+
+    async def test_retry_exhaustion_reraises_underlying_error(self, client):
+        with respx.mock:
+            route = respx.get(USER_URL).mock(
+                side_effect=httpx.ConnectError("connection refused")
+            )
+            with pytest.raises(httpx.ConnectError):
+                await client.get_user_detail()
+
+        assert route.call_count == 5  # stop_after_attempt, then reraise
+
+    async def test_override_persistent_401_not_retried(self, resumed_auth, monkeypatch):
+        from tenacity import wait_none
+
+        client = Evnex(auth=resumed_auth)
+        monkeypatch.setattr(Evnex.set_charge_point_override.retry, "wait", wait_none())
+        override_url = (
+            "https://client-api.evnex.io/charge-points/cp-1/commands/set-override"
         )
 
-    def test_rejected_code_raises_not_authorized(self, client):
-        client.cognito.respond_to_sms_mfa_challenge.side_effect = (
-            botocore.exceptions.ClientError(
-                {"Error": {"Code": "CodeMismatchException", "Message": "Wrong code"}},
-                "RespondToAuthChallenge",
+        with respx.mock:
+            route = respx.post(override_url).mock(return_value=httpx.Response(401))
+            with pytest.raises(ReauthenticationRequiredError):
+                await client.set_charge_point_override(
+                    charge_point_id="cp-1", charge_now=True
+                )
+
+        # One original send + exactly one auth-flow resend; the command was
+        # never submitted repeatedly
+        assert route.call_count == 2
+
+
+class TestErrorSurfaces:
+    """Exception mapping, datetime normalisation, and command retry safety."""
+
+    async def test_force_change_password_maps_to_typed_error(self, auth):
+        from pycognito.exceptions import ForceChangePasswordException
+
+        from evnex.errors import PasswordChangeRequiredError
+
+        await auth.start_authentication("u", "p")  # builds the fake cognito
+        auth._cognito.authenticate.side_effect = ForceChangePasswordException(
+            "Change your password"
+        )
+
+        with pytest.raises(PasswordChangeRequiredError):
+            await auth.start_authentication("u", "p")
+
+    async def test_token_verification_failure_on_refresh(self, resumed_auth):
+        from pycognito.exceptions import TokenVerificationException
+
+        await asyncio.to_thread(resumed_auth._ensure_cognito)  # lazy build
+        resumed_auth._cognito.renew_access_token.side_effect = (
+            TokenVerificationException("Your access token could not be verified")
+        )
+
+        with pytest.raises(ReauthenticationRequiredError):
+            await resumed_auth.force_refresh(stale_access_token="access-0")
+
+    async def test_naive_expires_at_is_normalised_to_utc(self):
+        from datetime import UTC, datetime
+
+        naive = datetime(2030, 1, 1, 12, 0, 0)
+        tokens = TokenSet(access_token="access-0", expires_at=naive)
+        assert tokens.expires_at.tzinfo is UTC
+
+        # And the expiry comparison in get_access_token no longer raises
+        auth = EvnexAuth(
+            tokens=TokenSet(
+                access_token="access-0",
+                refresh_token="refresh-0",
+                expires_at=datetime(2020, 1, 1),  # naive, in the past
             )
         )
-        with pytest.raises(NotAuthorizedException):
-            client.respond_to_mfa_challenge("123456", "SMS")
+        assert await auth.get_access_token() == "access-1"
+
+    async def test_command_http_error_not_retried(self, resumed_auth):
+        client = Evnex(auth=resumed_auth)
+        override_url = (
+            "https://client-api.evnex.io/charge-points/cp-1/commands/set-override"
+        )
+
+        with respx.mock:
+            route = respx.post(override_url).mock(return_value=httpx.Response(503))
+            with pytest.raises(httpx.HTTPStatusError):
+                await client.set_charge_point_override(
+                    charge_point_id="cp-1", charge_now=True
+                )
+
+        # The command was submitted exactly once
+        assert route.call_count == 1
+
+    def test_challenge_repr_redacts_username(self):
+        challenge = AuthChallenge(
+            name=CHALLENGE_SOFTWARE_TOKEN_MFA,
+            session="opaque",
+            username="user@example.com",
+        )
+        assert "user@example.com" not in repr(challenge)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -4,8 +4,8 @@ from evnex.schema.user import EvnexGetUserResponse
 from evnex.schema.v3.charge_points import EvnexChargePointConnectorMeter
 
 
-# https://github.com/hardbyte/python-evnex/issues/108
 def test_user_without_name_validates():
+    # The API omits the name field entirely for accounts that never set one
     payload = {
         "data": {
             "id": "b102b5e3-2b00-4f6b-9b0c-b579c609f969",
@@ -21,7 +21,6 @@ def test_user_without_name_validates():
     assert user.email == "user@example.com"
 
 
-# https://github.com/hardbyte/python-evnex/issues/109
 def test_connector_meter_exposes_supply_active_power():
     # Captured from a live v3 charge point detail response for a charger
     # with the PowerSensor feature (CT clamp) installed

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "evnex"
-version = "0.6.1"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
@@ -392,6 +392,7 @@ dependencies = [
     { name = "pycognito" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "tenacity" },
 ]
 
@@ -414,6 +415,7 @@ requires-dist = [
     { name = "pycognito", specifier = ">=2023.5.0,<2025" },
     { name = "pydantic", specifier = ">2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.2,<3.0" },
+    { name = "pyjwt", specifier = ">=2.8,<3.0" },
     { name = "tenacity", specifier = ">=8.1,<10.0" },
 ]
 


### PR DESCRIPTION
Implements #113 per the design doc included in the PR (`docs/design/113-auth-refactor.md`), with the decisions we resolved: exceptions subclass `NotAuthorizedException` for compat, clean break on the constructor, bare method names.

## New public API (`evnex.auth`)

- **`TokenSet`** / **`AuthChallenge`** — frozen, JSON-serializable dataclasses; tokens repr-redacted; expiry auto-derived from the JWT `exp` claim; the challenge carries the username Cognito needs, so it can be answered by another process.
- **`EvnexAuth`** — holds no credentials. `start_authentication(username, password)` / `respond_to_challenge(challenge, code)` return `TokenSet | AuthChallenge` (chaining-proof). A refresh token alone resumes a session. Every newly issued token set is awaited through `on_token_update` **under the auth lock, before any request proceeds** — atomic persistence for HA. pycognito/boto3 construction is lazy inside a worker thread (its constructor blocks — found via HA's blocking-call detector).
- **Typed errors** replace pycognito leakage: `InvalidCredentialsError`, `ReauthenticationRequiredError`, `ChallengeExpiredError`, `InvalidChallengeResponseError` — all `NotAuthorizedException` subclasses.
- **`EvnexHttpxAuth`** — 401 recovery moves into the transport: inject token, on 401 do one single-flight refresh + one resend. Auth recovery is now structurally independent of the tenacity transient-retry policy, and a single `_request` path replaces the per-method decorators (which twice shipped missing from endpoints).

## Breaking changes (0.7.0)

`Evnex(username, password, ...)`, sync `authenticate()`/`respond_to_mfa_challenge()`, and the token properties are removed. Construct with `Evnex(auth=EvnexAuth(...))`. README and all examples updated; ha-evnex adoption is tracked in hardbyte/ha-evnex#91.

## Testing

26 unit tests (fake Cognito + respx + blockbuster) covering the token lifecycle, challenge round-trips, single-flight concurrency, exactly-one-resend on 401, and callback failure tolerance. **Live-validated against the real API**: cross-process MFA challenge answer, refresh-token-only resumption, and a corrupted-token 401 recovering through the transport refresh.