### PR TITLE
MFA device management, password flows, and a uvx-runnable CLI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: ruff-format
         types_or: [ python, pyi ]
   - repo: https://github.com/JelleZijlstra/autotyping
-    rev: master
+    rev: 24.9.0
     hooks:
       - id: autotyping
         stages: [ pre-commit ]

--- a/README.md
+++ b/README.md
@@ -104,6 +104,82 @@ once, transparently. When the session truly can't be renewed, calls raise
 
 See `examples/get_token.py` for a complete sign-in and persistence flow.
 
+### Managing MFA devices
+
+The EVNEX app doesn't currently expose changing or removing your MFA device;
+the API does, and `EvnexAuth` wraps it (requires a signed-in session):
+
+```python
+status = await auth.get_mfa_status()          # which methods are enabled
+
+enrollment = await auth.begin_totp_enrollment()
+print(enrollment.provisioning_uri("you@example.com"))  # render as QR code
+await auth.confirm_totp_enrollment(code, device_name="New phone")
+await auth.set_mfa_preference(totp=True)      # turn TOTP on / make preferred
+
+await auth.set_mfa_preference()               # disable MFA entirely
+```
+
+Completing a new TOTP enrollment replaces the previously registered
+authenticator device.
+
+### Changing or resetting your password
+
+`EvnexAuth` also manages the account password:
+
+```python
+# Change the password of a signed-in account:
+await auth.change_password(current_password, new_password)
+
+# Reset a forgotten password (no session needed):
+destination = await auth.start_password_reset("you@example.com")  # masked email
+await auth.confirm_password_reset("you@example.com", emailed_code, new_password)
+```
+
+The CLI equivalents are `evnex auth change-password` (prompts for the current
+and new password) and `evnex auth reset-password` (sends a code to your email,
+then prompts for the code and a new password).
+
+## Command line
+
+Everything above is also available as a CLI, runnable directly with
+[uv](https://docs.astral.sh/uv/):
+
+```shell
+export EVNEX_CLIENT_USERNAME=you@example.com
+export EVNEX_CLIENT_PASSWORD=<your password>
+
+uvx evnex auth login                 # sign in (uses cached tokens when valid)
+uvx evnex auth status                # signed-in user, session, and MFA state
+uvx evnex auth logout                # forget the cached session
+uvx evnex auth mfa enable            # enroll a TOTP device and turn MFA on
+uvx evnex auth mfa disable           # turn MFA off entirely
+uvx evnex auth change-password       # change your password (prompts)
+uvx evnex auth reset-password        # reset a forgotten password via email
+```
+
+`evnex auth status` shows who you are signed in as (decoded from the cached
+token), when the session expires, and which MFA methods are enabled.
+
+`evnex auth mfa enable` is the interactive one-shot: it prints an `otpauth://`
+URI (paste it straight into a password manager's one-time password field),
+the bare secret, and a QR code, then asks for a code from the new device and
+makes TOTP the preferred method. For automation, the same flow is split into
+`evnex auth mfa enroll` (print the URI/secret/QR and exit) and
+`evnex auth mfa confirm CODE` (verify and enable; `--no-prefer` registers the
+device without changing the MFA preference). The QR code renders in the
+terminal, or in the browser with `--browser`.
+
+Session tokens are cached (mode 0600, `~/.cache/evnex/tokens.json` by default,
+or `EVNEX_TOKEN_CACHE`) so an MFA sign-in is only needed occasionally. To
+answer sign-in challenges from a password manager instead of typing codes —
+for example with the [1Password CLI](https://developer.1password.com/docs/cli/)
+v2+:
+
+```shell
+uvx evnex auth login --otp-command 'op item get Evnex --otp'
+```
+
 ## Examples
 
 `python-evnex` is intended as a library, but a few example scripts are provided in the `examples` folder.

--- a/evnex/auth.py
+++ b/evnex/auth.py
@@ -17,7 +17,8 @@ import logging
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
-from typing import Any
+from typing import Any, TypeVar
+from urllib.parse import quote
 
 import botocore.exceptions
 import httpx
@@ -50,6 +51,8 @@ CHALLENGE_SMS_MFA = "SMS_MFA"
 EXPIRY_SKEW = timedelta(seconds=30)
 
 TokenUpdateCallback = Callable[["TokenSet"], Awaitable[None]]
+
+_T = TypeVar("_T")
 
 # Sentinel distinguishing "always refresh" from "refresh unless the tokens
 # already rotated past this stale access token (which may be None)"
@@ -133,6 +136,31 @@ class AuthChallenge:
             username=data["username"],
             parameters=dict(data.get("parameters") or {}),
         )
+
+
+@dataclass(frozen=True, slots=True)
+class TotpEnrollment:
+    """A pending TOTP device enrollment: load the secret, then confirm."""
+
+    secret: str = field(repr=False)
+
+    def provisioning_uri(self, account_name: str, issuer: str = "Evnex") -> str:
+        """An otpauth:// URI for QR rendering or a password manager's OTP field.
+
+        Matches the label/issuer conventions of EVNEX's own enrollment.
+        """
+        return (
+            f"otpauth://totp/{quote(account_name)}"
+            f"?secret={self.secret}&issuer={quote(issuer)}"
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MfaStatus:
+    """The MFA methods currently enabled for an account."""
+
+    enabled: tuple[str, ...]
+    preferred: str | None = None
 
 
 class EvnexAuth:
@@ -335,6 +363,240 @@ class EvnexAuth:
                 raise ReauthenticationRequiredError(str(err)) from err
             await self._store_tokens(tokens)
             return tokens
+
+    async def _run_user_pool_op(
+        self,
+        operation: Callable[[str], _T],
+        *,
+        after: Callable[[_T], Awaitable[None]] | None = None,
+    ) -> _T:
+        """Run a Cognito user-pool call, recovering from server-side revocation.
+
+        operation is a synchronous callable given the resolved access token;
+        it runs in a worker thread while the lock is held, so it may touch the
+        shared Cognito instance. If Cognito rejects the token with
+        NotAuthorizedException — which get_access_token's local expiry check
+        cannot detect — the session is refreshed and the call retried exactly
+        once; a second failure propagates the ClientError for the caller's own
+        error mapping.
+
+        after, if given, runs under the same lock as the successful call (so
+        change_password can publish rotated tokens captured during it).
+
+        force_refresh acquires self._lock, so the refresh happens outside the
+        locked section: the loop alternates lock-held attempts with unlocked
+        refreshes rather than nesting the two.
+        """
+        access_token = await self.get_access_token()
+        refreshed_once = False
+        while True:
+            async with self._lock:
+                try:
+                    result = await asyncio.to_thread(operation, access_token)
+                except botocore.exceptions.ClientError as err:
+                    code = err.response.get("Error", {}).get("Code", "")
+                    if refreshed_once or code != "NotAuthorizedException":
+                        raise
+                else:
+                    if after is not None:
+                        await after(result)
+                    return result
+            refreshed_once = True
+            refreshed = await self.force_refresh(stale_access_token=access_token)
+            access_token = self._require_access_token(refreshed)
+
+    async def get_mfa_status(self) -> MfaStatus:
+        """Report which MFA methods are enabled for the signed-in account."""
+
+        def _get_user(access_token: str) -> MfaStatus:
+            cognito = self._ensure_cognito()
+            response = cognito.client.get_user(AccessToken=access_token)
+            return MfaStatus(
+                enabled=tuple(response.get("UserMFASettingList") or ()),
+                preferred=response.get("PreferredMfaSetting"),
+            )
+
+        try:
+            return await self._run_user_pool_op(_get_user)
+        except botocore.exceptions.ClientError as err:
+            raise EvnexAuthError(_error_message(err)) from err
+
+    async def begin_totp_enrollment(self) -> TotpEnrollment:
+        """Start enrolling a (new) TOTP authenticator device.
+
+        Returns the shared secret to load into the authenticator — via QR
+        code (see TotpEnrollment.provisioning_uri) or manual entry — then
+        confirm with confirm_totp_enrollment(). Completing enrollment
+        replaces any previously registered TOTP device.
+        """
+
+        def _associate(access_token: str) -> TotpEnrollment:
+            cognito = self._ensure_cognito()
+            cognito.access_token = access_token
+            return TotpEnrollment(secret=cognito.associate_software_token())
+
+        try:
+            return await self._run_user_pool_op(_associate)
+        except botocore.exceptions.ClientError as err:
+            raise EvnexAuthError(_error_message(err)) from err
+
+    async def confirm_totp_enrollment(self, code: str, device_name: str = "") -> None:
+        """Verify a code from the newly enrolled authenticator device.
+
+        Note this registers the device but does not turn MFA on for the
+        account; call set_mfa_preference(totp=True) as well when first
+        enabling MFA.
+
+        :raises InvalidChallengeResponseError: the code was rejected
+        """
+
+        def _verify(access_token: str) -> bool:
+            cognito = self._ensure_cognito()
+            cognito.access_token = access_token
+            return bool(cognito.verify_software_token(code.strip(), device_name))
+
+        try:
+            verified = await self._run_user_pool_op(_verify)
+        except botocore.exceptions.ClientError as err:
+            code_name = err.response.get("Error", {}).get("Code", "")
+            if code_name in (
+                "CodeMismatchException",
+                "EnableSoftwareTokenMFAException",
+            ):
+                raise InvalidChallengeResponseError(_error_message(err)) from err
+            raise EvnexAuthError(_error_message(err)) from err
+        if not verified:
+            raise InvalidChallengeResponseError("The code was not accepted")
+
+    async def set_mfa_preference(
+        self,
+        *,
+        totp: bool = False,
+        sms: bool = False,
+        preferred: str | None = None,
+    ) -> None:
+        """Enable, disable, or reprioritise MFA methods for the account.
+
+        With both flags False, MFA is disabled entirely (where the user
+        pool allows it). preferred is "SMS" or "SOFTWARE_TOKEN"; it may be
+        omitted when only one method is enabled.
+
+        :raises ValueError: both methods are enabled but no preferred one is
+            given — a preference is required to break the tie
+        """
+        if preferred is None and (totp ^ sms):
+            preferred = "SOFTWARE_TOKEN" if totp else "SMS"
+        if totp and sms and preferred is None:
+            raise ValueError(
+                "preferred is required when enabling both TOTP and SMS MFA; "
+                'pass preferred="SOFTWARE_TOKEN" or preferred="SMS"'
+            )
+
+        def _set_preference(access_token: str) -> None:
+            cognito = self._ensure_cognito()
+            cognito.access_token = access_token
+            cognito.set_user_mfa_preference(
+                sms_mfa=sms, software_token_mfa=totp, preferred=preferred
+            )
+
+        try:
+            await self._run_user_pool_op(_set_preference)
+        except botocore.exceptions.ClientError as err:
+            raise EvnexAuthError(_error_message(err)) from err
+
+    async def change_password(self, current_password: str, new_password: str) -> None:
+        """Change the password of the signed-in account.
+
+        Requires a usable session.
+
+        :raises InvalidCredentialsError: the current password was wrong
+        :raises EvnexAuthError: the new password was rejected, or a rate
+            limit was hit
+        """
+
+        def _change(access_token: str) -> TokenSet | None:
+            cognito = self._ensure_cognito()
+            cognito.access_token = access_token
+            current = self._tokens
+            cognito.id_token = current.id_token if current else None
+            cognito.refresh_token = current.refresh_token if current else None
+            cognito.change_password(current_password, new_password)
+            # pycognito's change_password runs check_token(renew=True), which
+            # can rotate tokens on the Cognito object; capture the rotation
+            # here — under the same lock as the call — so it is published
+            # rather than silently dropped.
+            if cognito.access_token != access_token:
+                return self._tokens_from_cognito(cognito)
+            return None
+
+        async def _publish(rotated: TokenSet | None) -> None:
+            if rotated is not None:
+                await self._store_tokens(rotated)
+
+        try:
+            await self._run_user_pool_op(_change, after=_publish)
+        except botocore.exceptions.ClientError as err:
+            code = err.response.get("Error", {}).get("Code", "")
+            if code == "NotAuthorizedException":
+                raise InvalidCredentialsError(_error_message(err)) from err
+            raise EvnexAuthError(_error_message(err)) from err
+
+    async def start_password_reset(self, username: str) -> str:
+        """Begin the forgot-password flow, sending a reset code to the user.
+
+        Needs no session. Returns a human-readable description of where the
+        code was delivered (e.g. a masked email address), or "" if the
+        server did not report a destination. Complete the reset with
+        confirm_password_reset().
+
+        :raises EvnexAuthError: the request was rejected (e.g. a rate limit)
+        """
+
+        def _start() -> str:
+            cognito = self._ensure_cognito()
+            cognito.username = username
+            # pycognito's initiate_forgot_password discards the boto3
+            # response, so call forgot_password directly to read the
+            # delivery details. This client has no secret, so no SECRET_HASH
+            # is required.
+            response = cognito.client.forgot_password(
+                ClientId=self._config.EVNEX_COGNITO_CLIENT_ID,
+                Username=username,
+            )
+            delivery = response.get("CodeDeliveryDetails") or {}
+            return str(delivery.get("Destination") or "")
+
+        async with self._lock:
+            try:
+                return await asyncio.to_thread(_start)
+            except botocore.exceptions.ClientError as err:
+                raise EvnexAuthError(_error_message(err)) from err
+
+    async def confirm_password_reset(
+        self, username: str, code: str, new_password: str
+    ) -> None:
+        """Complete the forgot-password flow with the emailed/texted code.
+
+        :raises InvalidChallengeResponseError: the reset code was wrong
+        :raises ChallengeExpiredError: the reset code expired
+        :raises EvnexAuthError: the new password was rejected
+        """
+
+        def _confirm() -> None:
+            cognito = self._ensure_cognito()
+            cognito.username = username
+            cognito.confirm_forgot_password(code.strip(), new_password)
+
+        async with self._lock:
+            try:
+                await asyncio.to_thread(_confirm)
+            except botocore.exceptions.ClientError as err:
+                code_name = err.response.get("Error", {}).get("Code", "")
+                if code_name == "CodeMismatchException":
+                    raise InvalidChallengeResponseError(_error_message(err)) from err
+                if code_name == "ExpiredCodeException":
+                    raise ChallengeExpiredError(_error_message(err)) from err
+                raise EvnexAuthError(_error_message(err)) from err
 
     def _ensure_cognito(self) -> Cognito:
         """Build the pycognito client on first use.

--- a/evnex/cli.py
+++ b/evnex/cli.py
@@ -1,0 +1,467 @@
+"""Command line interface for the EVNEX Cloud API client.
+
+Run without installing anything via uv:
+
+    uvx evnex auth login
+    uvx evnex auth status
+    uvx evnex auth mfa enable
+    uvx evnex auth change-password
+    uvx evnex auth reset-password
+
+Credentials come from EVNEX_CLIENT_USERNAME / EVNEX_CLIENT_PASSWORD (or are
+prompted for). Session tokens are cached with 0600 permissions so an MFA
+sign-in is only needed occasionally, not per command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import getpass
+import json
+import os
+import sys
+import tempfile
+import webbrowser
+from importlib.metadata import version
+from pathlib import Path
+
+import jwt
+
+from evnex.auth import AuthChallenge, EvnexAuth, TokenSet, TotpEnrollment
+from evnex.errors import EvnexAuthError, ReauthenticationRequiredError
+
+DEFAULT_CACHE = (
+    Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    / "evnex"
+    / "tokens.json"
+)
+
+# The interactive input()/getpass() prompts throughout this module block the
+# event loop on purpose: this is a single-task CLI process, so there is no
+# concurrent work for them to hold up.
+
+
+def _default_cache() -> Path:
+    override = os.environ.get("EVNEX_TOKEN_CACHE")
+    return Path(override) if override else DEFAULT_CACHE
+
+
+def _save_tokens_factory(cache: Path):
+    async def save_tokens(tokens: TokenSet) -> None:
+        # EvnexAuth awaits this callback under its lock, so keep the blocking
+        # filesystem work off the event loop.
+        def _write() -> None:
+            cache.parent.mkdir(parents=True, exist_ok=True)
+            # os.open + fchmod pins the mode to 0600 even when the cache file
+            # already exists; touch(mode=…) leaves a pre-existing file's
+            # permissions untouched.
+            fd = os.open(cache, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            try:
+                os.fchmod(fd, 0o600)
+                os.write(fd, json.dumps(tokens.to_dict()).encode())
+            finally:
+                os.close(fd)
+
+        await asyncio.to_thread(_write)
+
+    return save_tokens
+
+
+def _load_tokens(cache: Path) -> TokenSet | None:
+    if cache.is_file():
+        try:
+            return TokenSet.from_dict(json.loads(cache.read_text()))
+        except (ValueError, KeyError):
+            print(f"Ignoring unreadable token cache at {cache}", file=sys.stderr)
+    return None
+
+
+async def _challenge_code(args: argparse.Namespace, challenge: AuthChallenge) -> str:
+    if args.otp:
+        code, args.otp = args.otp, None  # a code is single-use
+        return str(code)
+    if args.otp_command:
+        proc = await asyncio.create_subprocess_shell(
+            args.otp_command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await proc.communicate()
+        code = stdout.decode().strip()
+        if proc.returncode != 0:
+            if stderr.strip():
+                print(stderr.decode().rstrip(), file=sys.stderr)
+            print(f"--otp-command failed (exit {proc.returncode})", file=sys.stderr)
+            sys.exit(1)
+        if not code:
+            print("--otp-command produced no code", file=sys.stderr)
+            sys.exit(1)
+        print("Code obtained from --otp-command", file=sys.stderr)
+        return code
+    return input(f"Enter the 6-digit code ({challenge.name}): ")
+
+
+async def signed_in_auth(args: argparse.Namespace) -> EvnexAuth:
+    """Return an EvnexAuth with a usable session, signing in if needed."""
+    cache: Path = args.token_cache
+    auth = EvnexAuth(
+        tokens=_load_tokens(cache), on_token_update=_save_tokens_factory(cache)
+    )
+    if auth.tokens is not None:
+        try:
+            await auth.get_access_token()
+            return auth
+        except ReauthenticationRequiredError:
+            print("Cached session expired; signing in again", file=sys.stderr)
+
+    username = os.environ.get("EVNEX_CLIENT_USERNAME") or input("EVNEX username: ")
+    password = os.environ.get("EVNEX_CLIENT_PASSWORD") or getpass.getpass(
+        "EVNEX password: "
+    )
+    result = await auth.start_authentication(username, password)
+    while isinstance(result, AuthChallenge):
+        result = await auth.respond_to_challenge(
+            result, await _challenge_code(args, result)
+        )
+    print(f"Signed in as {username}; session cached at {cache}", file=sys.stderr)
+    return auth
+
+
+def show_qr(uri: str, open_browser: bool) -> None:
+    """Render the enrollment QR in the terminal, and optionally a browser."""
+    try:
+        import qrcode
+        import qrcode.image.svg
+    except ImportError:
+        print(
+            "(install the qrcode package for a scannable QR code)",
+            file=sys.stderr,
+        )
+        return
+
+    qr = qrcode.QRCode(border=2)
+    qr.add_data(uri)
+    qr.print_ascii(tty=sys.stdout.isatty())
+    if open_browser:
+        image = qrcode.make(uri, image_factory=qrcode.image.svg.SvgPathImage)
+        # Prefer $XDG_RUNTIME_DIR (tmpfs, cleared at logout) for a file that
+        # holds a live MFA secret; fall back to the default temp dir. The
+        # browser reads it after we return, so it cannot be auto-deleted.
+        runtime_dir = os.environ.get("XDG_RUNTIME_DIR") or None
+        with tempfile.NamedTemporaryFile(
+            suffix=".svg", dir=runtime_dir, delete=False, mode="wb"
+        ) as f:
+            image.save(f)
+        os.chmod(f.name, 0o600)
+        webbrowser.open(f"file://{f.name}")
+        print(
+            f"QR code written to {f.name}\n"
+            "This file contains your MFA secret; delete it after scanning.",
+            file=sys.stderr,
+        )
+
+
+def _enrollment_account() -> str:
+    return os.environ.get("EVNEX_CLIENT_USERNAME", "evnex-account")
+
+
+def _print_enrollment(enrollment: TotpEnrollment, *, open_browser: bool) -> None:
+    """Print the otpauth URI, bare secret, and QR code for a TOTP enrollment."""
+    uri = enrollment.provisioning_uri(_enrollment_account())
+    print("Scan the QR code with your authenticator app, or paste the")
+    print("otpauth URI into a password manager's one-time password field:\n")
+    print(f"  {uri}\n")
+    print(f"(bare secret for manual entry: {enrollment.secret})\n")
+    show_qr(uri, open_browser=open_browser)
+
+
+async def cmd_login(args: argparse.Namespace) -> None:
+    await signed_in_auth(args)
+
+
+async def cmd_logout(args: argparse.Namespace) -> None:
+    cache: Path = args.token_cache
+
+    def _remove() -> bool:
+        if cache.is_file():
+            cache.unlink()
+            return True
+        return False
+
+    if await asyncio.to_thread(_remove):
+        print(f"Removed cached session at {cache}")
+    else:
+        print("No cached session")
+
+
+async def cmd_status(args: argparse.Namespace) -> None:
+    auth = await signed_in_auth(args)
+    tokens = auth.tokens
+    if tokens is None or not tokens.id_token:
+        identity = "unknown (no identity token cached)"
+    else:
+        try:
+            claims = jwt.decode(tokens.id_token, options={"verify_signature": False})
+        except jwt.InvalidTokenError:
+            claims = {}
+        identity = claims.get("email") or claims.get("cognito:username") or "unknown"
+    print(f"Signed in as: {identity}")
+    if tokens is not None and tokens.expires_at is not None:
+        print(f"Access token expires: {tokens.expires_at.isoformat()}")
+    print(f"Token cache: {args.token_cache}")
+
+    status = await auth.get_mfa_status()
+    if not status.enabled:
+        print("MFA: disabled")
+        return
+    print("MFA methods:")
+    for method in status.enabled:
+        marker = " (preferred)" if method == status.preferred else ""
+        print(f"  {method}{marker}")
+
+
+async def cmd_change_password(args: argparse.Namespace) -> None:
+    auth = await signed_in_auth(args)
+    current = getpass.getpass("Current password: ")
+    new = getpass.getpass("New password: ")
+    confirm = getpass.getpass("Confirm new password: ")
+    if new != confirm:
+        print("New passwords did not match. Aborted.", file=sys.stderr)
+        sys.exit(1)
+    await auth.change_password(current, new)
+    print("Password changed")
+
+
+async def cmd_reset_password(args: argparse.Namespace) -> None:
+    # The forgot-password flow needs no signed-in session.
+    auth = EvnexAuth()
+    username = os.environ.get("EVNEX_CLIENT_USERNAME") or input("EVNEX username: ")
+    destination = await auth.start_password_reset(username)
+    if destination:
+        print(f"A reset code was sent to {destination}")
+    else:
+        print("A reset code was sent; check your email")
+    code = input("Enter the reset code: ")
+    new = getpass.getpass("New password: ")
+    confirm = getpass.getpass("Confirm new password: ")
+    if new != confirm:
+        print("New passwords did not match. Aborted.", file=sys.stderr)
+        sys.exit(1)
+    await auth.confirm_password_reset(username, code, new)
+    print("Password reset; sign in again with the new password")
+
+
+async def cmd_mfa_enable(args: argparse.Namespace) -> None:
+    auth = await signed_in_auth(args)
+    enrollment = await auth.begin_totp_enrollment()
+    _print_enrollment(enrollment, open_browser=args.browser)
+
+    code = input("Enter a code from the new device: ")
+    await auth.confirm_totp_enrollment(code, args.device_name)
+    await auth.set_mfa_preference(totp=True)
+    print("TOTP device registered and set as the preferred MFA method")
+
+
+async def cmd_mfa_disable(args: argparse.Namespace) -> None:
+    if not args.yes:
+        answer = input("Disable MFA on this account? [y/N] ")
+        if answer.strip().lower() not in ("y", "yes"):
+            print("Aborted.", file=sys.stderr)
+            sys.exit(1)
+    auth = await signed_in_auth(args)
+    await auth.set_mfa_preference()
+    print("MFA disabled")
+
+
+async def cmd_mfa_enroll(args: argparse.Namespace) -> None:
+    auth = await signed_in_auth(args)
+    enrollment = await auth.begin_totp_enrollment()
+    _print_enrollment(enrollment, open_browser=args.browser)
+    print("\nThen run: evnex auth mfa confirm CODE [--device-name NAME]")
+
+
+async def cmd_mfa_confirm(args: argparse.Namespace) -> None:
+    auth = await signed_in_auth(args)
+    await auth.confirm_totp_enrollment(args.totp_code, args.device_name)
+    if args.prefer:
+        await auth.set_mfa_preference(totp=True)
+        print("TOTP device registered and set as the preferred MFA method")
+    else:
+        print("TOTP device registered (MFA preference unchanged)")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="evnex",
+        description="Command line interface for the EVNEX Cloud API.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"evnex {version('evnex')}",
+    )
+    parser.set_defaults(func=None, print_group_help=parser.print_help)
+
+    # Flags for commands that read or write the token cache.
+    cache_flags = argparse.ArgumentParser(add_help=False)
+    cache_flags.add_argument(
+        "--token-cache",
+        type=Path,
+        default=_default_cache(),
+        help=f"where to cache session tokens (default: {_default_cache()})",
+    )
+    # Flags for commands that may need to answer a sign-in MFA challenge. Kept
+    # separate so commands that never sign in (logout) or need no session at
+    # all (reset-password) reject them instead of silently ignoring them.
+    otp_flags = argparse.ArgumentParser(add_help=False)
+    otp_flags.add_argument(
+        "--otp",
+        help="6-digit code to answer a sign-in MFA challenge non-interactively",
+    )
+    otp_flags.add_argument(
+        "--otp-command",
+        help="shell command printing a current MFA code, e.g. "
+        "'op item get Evnex --otp' with the 1Password CLI",
+    )
+
+    sub = parser.add_subparsers(dest="command")
+
+    auth = sub.add_parser(
+        "auth",
+        help="manage authentication and MFA for your EVNEX account",
+        description=(
+            "Sign in and manage MFA and passwords for your EVNEX account. "
+            "Credentials come from EVNEX_CLIENT_USERNAME / EVNEX_CLIENT_PASSWORD "
+            "or prompts; session tokens are cached so an MFA code is only "
+            "needed once."
+        ),
+    )
+    auth.set_defaults(print_group_help=auth.print_help)
+    auth_sub = auth.add_subparsers(dest="auth_command")
+
+    login = auth_sub.add_parser(
+        "login",
+        parents=[cache_flags, otp_flags],
+        help="sign in (using cached tokens when valid) and cache session tokens",
+    )
+    login.set_defaults(func=cmd_login)
+
+    logout = auth_sub.add_parser(
+        "logout",
+        parents=[cache_flags],
+        help="delete the cached session tokens",
+    )
+    logout.set_defaults(func=cmd_logout)
+
+    status = auth_sub.add_parser(
+        "status",
+        parents=[cache_flags, otp_flags],
+        help="show the signed-in user, session, and enabled MFA methods",
+    )
+    status.set_defaults(func=cmd_status)
+
+    change_password = auth_sub.add_parser(
+        "change-password",
+        parents=[cache_flags, otp_flags],
+        help="change the account password (prompts for current and new)",
+    )
+    change_password.set_defaults(func=cmd_change_password)
+
+    reset_password = auth_sub.add_parser(
+        "reset-password",
+        help="reset a forgotten password via an emailed code (no sign-in)",
+    )
+    reset_password.set_defaults(func=cmd_reset_password)
+
+    mfa = auth_sub.add_parser(
+        "mfa",
+        help="manage multi-factor authentication devices",
+        description="Enable, disable, or (re)enroll TOTP multi-factor authentication.",
+    )
+    mfa.set_defaults(print_group_help=mfa.print_help)
+    mfa_sub = mfa.add_subparsers(dest="mfa_command")
+
+    enable = mfa_sub.add_parser(
+        "enable",
+        parents=[cache_flags, otp_flags],
+        help="enroll a new TOTP device and make it the preferred MFA method",
+        description=(
+            "Interactive one-shot: prints the otpauth:// URI, bare secret, and "
+            "a QR code, prompts for a code from the new device, then registers "
+            "it and makes TOTP the preferred MFA method. Enrolling a new device "
+            "replaces any previously registered one."
+        ),
+    )
+    enable.add_argument("--device-name", default="", help="friendly device name")
+    enable.add_argument(
+        "--browser", action="store_true", help="also open the QR code in a browser"
+    )
+    enable.set_defaults(func=cmd_mfa_enable)
+
+    disable = mfa_sub.add_parser(
+        "disable",
+        parents=[cache_flags, otp_flags],
+        help="turn MFA off for the account",
+        description="Disable all MFA methods for the account.",
+    )
+    disable.add_argument(
+        "--yes", "-y", action="store_true", help="skip the confirmation prompt"
+    )
+    disable.set_defaults(func=cmd_mfa_disable)
+
+    enroll = mfa_sub.add_parser(
+        "enroll",
+        parents=[cache_flags, otp_flags],
+        help="print a TOTP enrollment URI/secret/QR and exit (for automation)",
+        description=(
+            "Plumbing command: start enrolling a TOTP device and print the "
+            "otpauth:// URI, bare secret, and QR code, then exit. Complete "
+            "enrollment with 'evnex auth mfa confirm CODE'."
+        ),
+    )
+    enroll.add_argument(
+        "--browser", action="store_true", help="also open the QR code in a browser"
+    )
+    enroll.set_defaults(func=cmd_mfa_enroll)
+
+    confirm = mfa_sub.add_parser(
+        "confirm",
+        parents=[cache_flags, otp_flags],
+        help="verify a code from a newly enrolled TOTP device (for automation)",
+        description=(
+            "Plumbing command: verify a code generated by the newly enrolled "
+            "device. By default this also makes TOTP the preferred MFA method."
+        ),
+    )
+    confirm.add_argument("totp_code", help="6-digit code from the new device")
+    confirm.add_argument("--device-name", default="", help="friendly device name")
+    confirm.add_argument(
+        "--no-prefer",
+        dest="prefer",
+        action="store_false",
+        help="register the device without changing the MFA preference",
+    )
+    confirm.set_defaults(func=cmd_mfa_confirm)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+    handler = getattr(args, "func", None)
+    if handler is None:
+        # No (leaf) subcommand: print the most specific help and exit cleanly.
+        args.print_group_help()
+        sys.exit(0)
+    try:
+        asyncio.run(handler(args))
+    except EvnexAuthError as err:
+        print(f"Authentication error: {err}", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,14 @@ dependencies = [
     "pydantic>2.0.0,<3.0.0",
     "tenacity>=8.1,<10.0",
     "pyjwt>=2.8,<3.0",
+    # QR rendering for the CLI; pure python, and uninstalling it is a
+    # supported opt-out (the CLI falls back to printing the otpauth URI)
+    "qrcode>=8.0",
     "pydantic-settings>=2.2,<3.0",
 ]
+
+[project.scripts]
+evnex = "evnex.cli:main"
 
 [dependency-groups]
 dev = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,6 +45,28 @@ class FakeCognito:
         self.respond_to_sms_mfa_challenge = MagicMock(
             side_effect=lambda code, mfa_tokens=None: self._issue_tokens()
         )
+        self.associate_software_token = MagicMock(
+            side_effect=self._block, return_value="FAKESECRETBASE32"
+        )
+        self.verify_software_token = MagicMock(
+            side_effect=self._block, return_value=True
+        )
+        self.set_user_mfa_preference = MagicMock(side_effect=self._block)
+        self.change_password = MagicMock(side_effect=self._block)
+        self.initiate_forgot_password = MagicMock(side_effect=self._block)
+        self.confirm_forgot_password = MagicMock(side_effect=self._block)
+        self.client = MagicMock()
+        self.client.get_user = MagicMock(
+            side_effect=self._block,
+            return_value={
+                "UserMFASettingList": ["SOFTWARE_TOKEN_MFA"],
+                "PreferredMfaSetting": "SOFTWARE_TOKEN_MFA",
+            },
+        )
+        self.client.forgot_password = MagicMock(
+            side_effect=self._block,
+            return_value={"CodeDeliveryDetails": {"Destination": "b***@e***"}},
+        )
 
     @staticmethod
     def _block(*args, **kwargs):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -35,7 +35,7 @@ USER_URL = "https://client-api.evnex.io/v2/apps/user"
 
 USER_PAYLOAD = {
     "data": {
-        "id": "b102b5e3-2b00-4f6b-9b0c-b579c609f969",
+        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
         "createdDate": "2022-01-01T00:00:00Z",
         "updatedDate": "2022-01-01T00:00:00Z",
         "name": "Test User",
@@ -453,3 +453,159 @@ class TestErrorSurfaces:
             username="user@example.com",
         )
         assert "user@example.com" not in repr(challenge)
+
+
+class TestMfaManagement:
+    async def test_mfa_status(self, resumed_auth):
+        status = await resumed_auth.get_mfa_status()
+
+        assert status.enabled == ("SOFTWARE_TOKEN_MFA",)
+        assert status.preferred == "SOFTWARE_TOKEN_MFA"
+
+    async def test_totp_enrollment_flow(self, resumed_auth):
+        enrollment = await resumed_auth.begin_totp_enrollment()
+
+        assert enrollment.secret == "FAKESECRETBASE32"
+        uri = enrollment.provisioning_uri("user@example.com")
+        assert uri.startswith("otpauth://totp/user%40example.com?")
+        assert "issuer=Evnex" in uri
+        assert "secret=FAKESECRETBASE32" in uri
+        assert "secret" not in repr(enrollment).lower() or "FAKESECRET" not in repr(
+            enrollment
+        )
+
+        await resumed_auth.confirm_totp_enrollment("123456", "New phone")
+        resumed_auth._cognito.verify_software_token.assert_called_once_with(
+            "123456", "New phone"
+        )
+
+    async def test_confirm_with_wrong_code(self, resumed_auth):
+        await resumed_auth.begin_totp_enrollment()  # builds the fake cognito
+        resumed_auth._cognito.verify_software_token.side_effect = client_error(
+            "EnableSoftwareTokenMFAException", "Code mismatch"
+        )
+
+        with pytest.raises(InvalidChallengeResponseError):
+            await resumed_auth.confirm_totp_enrollment("000000")
+
+    async def test_disable_mfa(self, resumed_auth):
+        await resumed_auth.set_mfa_preference(totp=False, sms=False)
+
+        resumed_auth._cognito.set_user_mfa_preference.assert_called_once_with(
+            sms_mfa=False, software_token_mfa=False, preferred=None
+        )
+
+    async def test_single_method_is_preferred_automatically(self, resumed_auth):
+        await resumed_auth.set_mfa_preference(totp=True)
+
+        resumed_auth._cognito.set_user_mfa_preference.assert_called_once_with(
+            sms_mfa=False, software_token_mfa=True, preferred="SOFTWARE_TOKEN"
+        )
+
+    async def test_both_methods_without_preferred_raises_valueerror(self, resumed_auth):
+        await resumed_auth.set_mfa_preference(totp=True)  # builds the fake cognito
+        resumed_auth._cognito.set_user_mfa_preference.reset_mock()
+
+        with pytest.raises(ValueError, match="preferred is required"):
+            await resumed_auth.set_mfa_preference(totp=True, sms=True)
+
+        # The misuse is caught by us; pycognito is never reached
+        resumed_auth._cognito.set_user_mfa_preference.assert_not_called()
+
+    async def test_revoked_access_token_refreshes_and_retries_once(self, resumed_auth):
+        await resumed_auth.set_mfa_preference(totp=True)  # builds the fake cognito
+        resumed_auth._cognito.set_user_mfa_preference.reset_mock()
+        resumed_auth._cognito.renew_access_token.reset_mock()
+        # A server-side revocation the local expiry check cannot see: reject
+        # the first call, then accept the retry with the refreshed token
+        resumed_auth._cognito.set_user_mfa_preference.side_effect = [
+            client_error("NotAuthorizedException", "Access Token has been revoked"),
+            None,
+        ]
+
+        await resumed_auth.set_mfa_preference(totp=True)
+
+        assert resumed_auth._cognito.set_user_mfa_preference.call_count == 2
+        resumed_auth._cognito.renew_access_token.assert_called_once()
+
+    async def test_persistent_revocation_propagates_after_one_retry(self, resumed_auth):
+        await resumed_auth.get_mfa_status()  # builds the fake cognito
+        resumed_auth._cognito.client.get_user.reset_mock()
+        resumed_auth._cognito.renew_access_token.reset_mock()
+        resumed_auth._cognito.client.get_user.side_effect = client_error(
+            "NotAuthorizedException", "Access Token has been revoked"
+        )
+
+        with pytest.raises(EvnexAuthError):
+            await resumed_auth.get_mfa_status()
+
+        # Retried exactly once, then the mapped error surfaces
+        assert resumed_auth._cognito.client.get_user.call_count == 2
+        resumed_auth._cognito.renew_access_token.assert_called_once()
+
+
+class TestPasswordManagement:
+    async def test_change_password(self, resumed_auth):
+        await resumed_auth.change_password("oldpass", "newpass")
+
+        resumed_auth._cognito.change_password.assert_called_once_with(
+            "oldpass", "newpass"
+        )
+
+    async def test_change_password_wrong_current(self, resumed_auth):
+        await resumed_auth.change_password("oldpass", "newpass")  # builds the fake
+        resumed_auth._cognito.change_password.side_effect = client_error(
+            "NotAuthorizedException", "Incorrect username or password."
+        )
+
+        with pytest.raises(InvalidCredentialsError):
+            await resumed_auth.change_password("wrongpass", "newpass")
+
+    async def test_change_password_invalid_new(self, resumed_auth):
+        await resumed_auth.change_password("oldpass", "newpass")  # builds the fake
+        resumed_auth._cognito.change_password.side_effect = client_error(
+            "InvalidPasswordException", "Password does not conform to policy"
+        )
+
+        with pytest.raises(EvnexAuthError, match="conform"):
+            await resumed_auth.change_password("oldpass", "weak")
+
+    async def test_start_password_reset_returns_destination(self, auth):
+        destination = await auth.start_password_reset("user@example.com")
+
+        assert destination == "b***@e***"
+        auth._cognito.client.forgot_password.assert_called_once()
+
+    async def test_confirm_password_reset(self, auth):
+        await auth.confirm_password_reset("user@example.com", "123456", "newpass")
+
+        auth._cognito.confirm_forgot_password.assert_called_once_with(
+            "123456", "newpass"
+        )
+
+    async def test_confirm_password_reset_wrong_code(self, auth):
+        await auth.start_password_reset("user@example.com")  # builds the fake
+        auth._cognito.confirm_forgot_password.side_effect = client_error(
+            "CodeMismatchException", "Invalid verification code provided"
+        )
+
+        with pytest.raises(InvalidChallengeResponseError):
+            await auth.confirm_password_reset("user@example.com", "000000", "newpass")
+
+    async def test_confirm_password_reset_expired_code(self, auth):
+        await auth.start_password_reset("user@example.com")  # builds the fake
+        auth._cognito.confirm_forgot_password.side_effect = client_error(
+            "ExpiredCodeException", "Invalid code provided, please request a code again"
+        )
+
+        with pytest.raises(ChallengeExpiredError):
+            await auth.confirm_password_reset("user@example.com", "123456", "newpass")
+
+    async def test_confirm_password_reset_invalid_new(self, auth):
+        await auth.start_password_reset("user@example.com")  # builds the fake
+        auth._cognito.confirm_forgot_password.side_effect = client_error(
+            "InvalidPasswordException", "Password does not conform to policy"
+        )
+
+        with pytest.raises(EvnexAuthError, match="conform"):
+            await auth.confirm_password_reset("user@example.com", "123456", "weak")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,220 @@
+"""Tests for the CLI parser wiring and command behaviour."""
+
+import argparse
+import asyncio
+
+import pytest
+
+from evnex.auth import AuthChallenge
+from evnex.cli import (
+    _challenge_code,
+    _load_tokens,
+    build_parser,
+    cmd_change_password,
+    cmd_login,
+    cmd_logout,
+    cmd_mfa_confirm,
+    cmd_mfa_disable,
+    cmd_mfa_enable,
+    cmd_mfa_enroll,
+    cmd_reset_password,
+    cmd_status,
+    main,
+)
+
+
+@pytest.mark.parametrize(
+    "func, argv",
+    [
+        (cmd_login, ["auth", "login"]),
+        (cmd_login, ["auth", "login", "--otp", "123456"]),
+        (cmd_logout, ["auth", "logout"]),
+        (cmd_status, ["auth", "status"]),
+        (cmd_change_password, ["auth", "change-password"]),
+        (cmd_reset_password, ["auth", "reset-password"]),
+        (cmd_mfa_enable, ["auth", "mfa", "enable", "--device-name", "x", "--browser"]),
+        (cmd_mfa_disable, ["auth", "mfa", "disable", "--yes"]),
+        (cmd_mfa_disable, ["auth", "mfa", "disable", "-y"]),
+        (cmd_mfa_enroll, ["auth", "mfa", "enroll", "--browser"]),
+        (cmd_mfa_confirm, ["auth", "mfa", "confirm", "123456", "--no-prefer"]),
+        (cmd_mfa_confirm, ["auth", "mfa", "confirm", "123456", "--device-name", "x"]),
+    ],
+)
+def test_leaf_commands_dispatch_to_their_handler(func, argv):
+    args = build_parser().parse_args(argv)
+    assert args.func is func
+
+
+def test_shared_flags_accepted_in_trailing_position():
+    args = build_parser().parse_args(
+        ["auth", "status", "--otp", "123456", "--token-cache", "/tmp/tokens.json"]
+    )
+    assert args.otp == "123456"
+    assert str(args.token_cache) == "/tmp/tokens.json"
+
+
+def test_otp_command_option_parses():
+    args = build_parser().parse_args(
+        ["auth", "login", "--otp-command", "op item get Evnex --otp"]
+    )
+    assert args.otp_command == "op item get Evnex --otp"
+
+
+def test_confirm_no_prefer_sets_prefer_false():
+    args = build_parser().parse_args(
+        ["auth", "mfa", "confirm", "123456", "--no-prefer"]
+    )
+    assert args.totp_code == "123456"
+    assert args.prefer is False
+
+
+def test_confirm_defaults_to_preferring():
+    args = build_parser().parse_args(["auth", "mfa", "confirm", "123456"])
+    assert args.prefer is True
+
+
+def test_version_exits_zero(capsys):
+    with pytest.raises(SystemExit) as exc:
+        build_parser().parse_args(["--version"])
+    assert exc.value.code == 0
+    assert "evnex" in capsys.readouterr().out
+
+
+def test_no_args_prints_help_and_exits_zero(capsys):
+    with pytest.raises(SystemExit) as exc:
+        main([])
+    assert exc.value.code == 0
+    assert "usage:" in capsys.readouterr().out.lower()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["auth", "signin"],
+        ["auth", "enroll-totp"],
+        ["auth", "confirm-totp", "123456"],
+        ["auth", "--code", "123456", "status"],
+    ],
+)
+def test_old_names_no_longer_parse(argv):
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(argv)
+
+
+@pytest.mark.parametrize("flag", ["--otp", "--otp-command", "--token-cache"])
+def test_reset_password_rejects_session_flags(flag):
+    # reset-password needs no session and no cache; the sign-in/cache flags
+    # must be rejected rather than silently ignored.
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["auth", "reset-password", flag, "x"])
+
+
+def test_logout_only_takes_token_cache():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["auth", "logout", "--otp", "123456"])
+
+
+class TestLogout:
+    # Driven via asyncio.run from sync tests so the filesystem setup happens
+    # off the event loop (blockbuster forbids blocking I/O while it runs).
+    def test_removes_present_cache(self, tmp_path, capsys):
+        cache = tmp_path / "tokens.json"
+        cache.write_text("{}")
+        args = argparse.Namespace(token_cache=cache)
+
+        asyncio.run(cmd_logout(args))
+
+        assert not cache.exists()
+        assert "Removed" in capsys.readouterr().out
+
+    def test_missing_cache_reports_nothing_to_do(self, tmp_path, capsys):
+        cache = tmp_path / "tokens.json"
+        args = argparse.Namespace(token_cache=cache)
+
+        asyncio.run(cmd_logout(args))
+
+        assert "No cached session" in capsys.readouterr().out
+
+
+class TestLoadTokens:
+    def test_corrupt_cache_warns_and_returns_none(self, tmp_path, capsys):
+        cache = tmp_path / "tokens.json"
+        cache.write_text("not valid json {{{")
+
+        assert _load_tokens(cache) is None
+        assert "unreadable" in capsys.readouterr().err.lower()
+
+    def test_missing_cache_returns_none(self, tmp_path):
+        assert _load_tokens(tmp_path / "absent.json") is None
+
+
+class TestPasswordMismatch:
+    def test_change_password_mismatch_exits_1(self, monkeypatch, capsys):
+        class FakeAuth:
+            async def change_password(self, *args):
+                raise AssertionError("password change must not run after mismatch")
+
+        async def fake_signed_in(args):
+            return FakeAuth()
+
+        monkeypatch.setattr("evnex.cli.signed_in_auth", fake_signed_in)
+        prompts = iter(["current", "new-one", "new-two"])
+        monkeypatch.setattr("getpass.getpass", lambda *a, **k: next(prompts))
+
+        with pytest.raises(SystemExit) as exc:
+            main(["auth", "change-password"])
+
+        assert exc.value.code == 1
+        assert "did not match" in capsys.readouterr().err.lower()
+
+    def test_reset_password_mismatch_exits_1(self, monkeypatch, capsys):
+        class FakeAuth:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            async def start_password_reset(self, username):
+                return ""
+
+            async def confirm_password_reset(self, *args):
+                raise AssertionError("reset must not run after mismatch")
+
+        monkeypatch.setattr("evnex.cli.EvnexAuth", FakeAuth)
+        monkeypatch.setenv("EVNEX_CLIENT_USERNAME", "user@example.com")
+        monkeypatch.setattr("builtins.input", lambda *a, **k: "123456")
+        prompts = iter(["new-one", "new-two"])
+        monkeypatch.setattr("getpass.getpass", lambda *a, **k: next(prompts))
+
+        with pytest.raises(SystemExit) as exc:
+            main(["auth", "reset-password"])
+
+        assert exc.value.code == 1
+        assert "did not match" in capsys.readouterr().err.lower()
+
+
+class TestOtpCommand:
+    challenge = AuthChallenge(name="SOFTWARE_TOKEN_MFA", session="s", username="u")
+
+    def test_failure_exits_1_and_reports(self, capsys):
+        args = argparse.Namespace(otp=None, otp_command="echo boom >&2; exit 3")
+
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(_challenge_code(args, self.challenge))
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "boom" in err
+        assert "otp-command failed (exit 3)" in err
+
+    def test_empty_output_exits_1(self, capsys):
+        args = argparse.Namespace(otp=None, otp_command="true")
+
+        with pytest.raises(SystemExit) as exc:
+            asyncio.run(_challenge_code(args, self.challenge))
+
+        assert exc.value.code == 1
+        assert "no code" in capsys.readouterr().err.lower()
+
+    def test_success_returns_stripped_code(self):
+        args = argparse.Namespace(otp=None, otp_command="echo 123456")
+
+        assert asyncio.run(_challenge_code(args, self.challenge)) == "123456"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -8,7 +8,7 @@ def test_user_without_name_validates():
     # The API omits the name field entirely for accounts that never set one
     payload = {
         "data": {
-            "id": "b102b5e3-2b00-4f6b-9b0c-b579c609f969",
+            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
             "createdDate": "2022-01-01T00:00:00Z",
             "updatedDate": "2022-01-01T00:00:00Z",
             "email": "user@example.com",

--- a/uv.lock
+++ b/uv.lock
@@ -393,6 +393,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
+    { name = "qrcode" },
     { name = "tenacity" },
 ]
 
@@ -416,6 +417,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.2,<3.0" },
     { name = "pyjwt", specifier = ">=2.8,<3.0" },
+    { name = "qrcode", specifier = ">=8.0" },
     { name = "tenacity", specifier = ">=8.1,<10.0" },
 ]
 
@@ -1023,6 +1025,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Follow-up to #114 (now merged). Replaces #115, which GitHub auto-closed when the stack base branch was deleted.

The EVNEX app lets you enable MFA but offers no way to change your authenticator device, turn MFA off, or manage your password from outside the app. The Cognito user-level APIs support all of it — this exposes typed async methods on `EvnexAuth` **and a packaged CLI**.

## Library (`evnex.auth`)

- **`get_mfa_status()`** → `MfaStatus(enabled, preferred)`
- **`begin_totp_enrollment()`** → `TotpEnrollment` with the shared secret (repr-redacted) and an `otpauth://` provisioning URI matching EVNEX's own enrollment conventions — paste-ready for password managers' OTP fields
- **`confirm_totp_enrollment(code, device_name)`** — completing a new enrollment **replaces** the previous authenticator device (the "change device" path)
- **`set_mfa_preference(totp=..., sms=...)`** — both off **disables MFA entirely** (the thing @erinn noted the app can't do)
- **`change_password(current, new)`** — signed-in password change
- **`start_password_reset(username)`** / **`confirm_password_reset(username, code, new)`** — the forgot-password flow (no session needed); typed errors for wrong/expired reset codes

## CLI (`uvx evnex`)

```
evnex auth
├── login / logout / status        # gh-style session management
├── change-password                # prompts via getpass, never CLI args
├── reset-password                 # emailed-code flow, no sign-in
└── mfa
    ├── enable                     # interactive one-shot: enroll → QR/URI → code → prefer
    ├── disable [--yes]
    ├── enroll / confirm CODE      # the same flow split for automation
```

Session tokens cache (0600) through `on_token_update`, so an MFA sign-in happens once. Shared flags work in trailing position on every command: `--otp 123456`, `--otp-command 'op item get Evnex --otp'` (1Password CLI v2+ or any secret-manager CLI), `--token-cache` / `EVNEX_TOKEN_CACHE`. `qrcode` is an optional extra (`uvx --with qrcode evnex auth mfa enable`); without it the otpauth URI and secret still print. No args → help; `--version` supported.

## Testing

61 tests total (parser wiring for every leaf incl. trailing flags, password flows, challenge/enrollment error mapping, single-flight concurrency, blockbuster). **MFA management live-validated end-to-end on a real account**: status → disable (fresh sign-in confirmed challenge-free) → enroll new TOTP device via QR → confirm → fresh sign-in challenged again with the new device's friendly name. Password change/reset are unit-tested; exercising them live rotates real credentials, so that's a post-review step.
