### PR TITLE
Add charge point, session, and control commands to the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,25 @@ uvx evnex auth mfa enable            # enroll a TOTP device and turn MFA on
 uvx evnex auth mfa disable           # turn MFA off entirely
 uvx evnex auth change-password       # change your password (prompts)
 uvx evnex auth reset-password        # reset a forgotten password via email
+
+uvx evnex status                     # live view: connectors, power, sessions
+uvx evnex charge-points list         # id, name, serial, network status
+uvx evnex charge-points show         # detail for one charge point
+uvx evnex sessions list              # recent charging sessions
+uvx evnex insights                   # daily energy, cost, and session counts
+uvx evnex charge now                 # start charging immediately
+uvx evnex charge auto                # return to the configured schedule
+uvx evnex charge stop                # stop the active charging session
+uvx evnex schedule show              # the configured charging schedule
+```
+
+The resource commands pick the charge point automatically when the account has
+only one; otherwise select it with `--charge-point ID`, where `ID` is a charge
+point id or a part of its name or serial of its name or serial. Add `--json` to `status`,
+the listings, and `schedule show` for a machine-readable document on stdout:
+
+```shell
+uvx evnex status --json
 ```
 
 `evnex auth status` shows who you are signed in as (decoded from the cached

--- a/evnex/cli/__init__.py
+++ b/evnex/cli/__init__.py
@@ -1,0 +1,132 @@
+"""Command line interface for the EVNEX Cloud API client.
+
+Run without installing anything via uv:
+
+    uvx evnex auth login
+    uvx evnex status
+    uvx evnex charge-points list
+    uvx evnex sessions list
+    uvx evnex charge now
+
+Credentials come from EVNEX_CLIENT_USERNAME / EVNEX_CLIENT_PASSWORD (or are
+prompted for). Session tokens are cached with 0600 permissions so an MFA
+sign-in is only needed occasionally, not per command.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from importlib.metadata import version
+from pathlib import Path
+
+import httpx
+from pydantic import ValidationError
+
+from evnex.cli._auth import (
+    _challenge_code,
+    _default_cache,
+    _load_tokens,
+    add_auth_commands,
+    cmd_change_password,
+    cmd_login,
+    cmd_logout,
+    cmd_mfa_confirm,
+    cmd_mfa_disable,
+    cmd_mfa_enable,
+    cmd_mfa_enroll,
+    cmd_reset_password,
+    cmd_status,
+    signed_in_auth,
+)
+from evnex.cli._resources import add_resource_commands
+from evnex.errors import EvnexAuthError
+
+__all__ = [
+    "_challenge_code",
+    "_load_tokens",
+    "build_parser",
+    "cmd_change_password",
+    "cmd_login",
+    "cmd_logout",
+    "cmd_mfa_confirm",
+    "cmd_mfa_disable",
+    "cmd_mfa_enable",
+    "cmd_mfa_enroll",
+    "cmd_reset_password",
+    "cmd_status",
+    "main",
+    "signed_in_auth",
+]
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="evnex",
+        description="Command line interface for the EVNEX Cloud API.",
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"evnex {version('evnex')}",
+    )
+    parser.set_defaults(func=None, print_group_help=parser.print_help)
+
+    # Flags for commands that read or write the token cache.
+    cache_flags = argparse.ArgumentParser(add_help=False)
+    cache_flags.add_argument(
+        "--token-cache",
+        type=Path,
+        default=_default_cache(),
+        help=f"where to cache session tokens (default: {_default_cache()})",
+    )
+    # Flags for commands that may need to answer a sign-in MFA challenge. Kept
+    # separate so commands that never sign in (logout) or need no session at
+    # all (reset-password) reject them instead of silently ignoring them.
+    otp_flags = argparse.ArgumentParser(add_help=False)
+    otp_flags.add_argument(
+        "--otp",
+        help="6-digit code to answer a sign-in MFA challenge non-interactively",
+    )
+    otp_flags.add_argument(
+        "--otp-command",
+        help="shell command printing a current MFA code, e.g. "
+        "'op item get Evnex --otp' with the 1Password CLI",
+    )
+
+    sub = parser.add_subparsers(dest="command")
+    add_auth_commands(sub, cache_flags, otp_flags)
+    add_resource_commands(sub, cache_flags, otp_flags)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = build_parser().parse_args(argv)
+    handler = getattr(args, "func", None)
+    if handler is None:
+        # No (leaf) subcommand: print the most specific help and exit cleanly.
+        args.print_group_help()
+        sys.exit(0)
+    try:
+        asyncio.run(handler(args))
+    except EvnexAuthError as err:
+        print(f"Authentication error: {err}", file=sys.stderr)
+        sys.exit(1)
+    except httpx.HTTPError as err:
+        print(f"API request failed: {err}", file=sys.stderr)
+        sys.exit(1)
+    except ValidationError:
+        print(
+            "The API returned a response this client version does not"
+            " understand; try upgrading evnex",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except KeyboardInterrupt:
+        sys.exit(130)
+
+
+if __name__ == "__main__":
+    main()

--- a/evnex/cli/_auth.py
+++ b/evnex/cli/_auth.py
@@ -1,16 +1,8 @@
-"""Command line interface for the EVNEX Cloud API client.
+"""Authentication, MFA, and password commands, plus shared sign-in helpers.
 
-Run without installing anything via uv:
-
-    uvx evnex auth login
-    uvx evnex auth status
-    uvx evnex auth mfa enable
-    uvx evnex auth change-password
-    uvx evnex auth reset-password
-
-Credentials come from EVNEX_CLIENT_USERNAME / EVNEX_CLIENT_PASSWORD (or are
-prompted for). Session tokens are cached with 0600 permissions so an MFA
-sign-in is only needed occasionally, not per command.
+The interactive input()/getpass() prompts throughout this module block the
+event loop on purpose: this is a single-task CLI process, so there is no
+concurrent work for them to hold up.
 """
 
 from __future__ import annotations
@@ -23,23 +15,18 @@ import os
 import sys
 import tempfile
 import webbrowser
-from importlib.metadata import version
 from pathlib import Path
 
 import jwt
 
 from evnex.auth import AuthChallenge, EvnexAuth, TokenSet, TotpEnrollment
-from evnex.errors import EvnexAuthError, ReauthenticationRequiredError
+from evnex.errors import ReauthenticationRequiredError
 
 DEFAULT_CACHE = (
     Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
     / "evnex"
     / "tokens.json"
 )
-
-# The interactive input()/getpass() prompts throughout this module block the
-# event loop on purpose: this is a single-task CLI process, so there is no
-# concurrent work for them to hold up.
 
 
 def _default_cache() -> Path:
@@ -291,42 +278,12 @@ async def cmd_mfa_confirm(args: argparse.Namespace) -> None:
         print("TOTP device registered (MFA preference unchanged)")
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="evnex",
-        description="Command line interface for the EVNEX Cloud API.",
-    )
-    parser.add_argument(
-        "--version",
-        action="version",
-        version=f"evnex {version('evnex')}",
-    )
-    parser.set_defaults(func=None, print_group_help=parser.print_help)
-
-    # Flags for commands that read or write the token cache.
-    cache_flags = argparse.ArgumentParser(add_help=False)
-    cache_flags.add_argument(
-        "--token-cache",
-        type=Path,
-        default=_default_cache(),
-        help=f"where to cache session tokens (default: {_default_cache()})",
-    )
-    # Flags for commands that may need to answer a sign-in MFA challenge. Kept
-    # separate so commands that never sign in (logout) or need no session at
-    # all (reset-password) reject them instead of silently ignoring them.
-    otp_flags = argparse.ArgumentParser(add_help=False)
-    otp_flags.add_argument(
-        "--otp",
-        help="6-digit code to answer a sign-in MFA challenge non-interactively",
-    )
-    otp_flags.add_argument(
-        "--otp-command",
-        help="shell command printing a current MFA code, e.g. "
-        "'op item get Evnex --otp' with the 1Password CLI",
-    )
-
-    sub = parser.add_subparsers(dest="command")
-
+def add_auth_commands(
+    sub: argparse._SubParsersAction,
+    cache_flags: argparse.ArgumentParser,
+    otp_flags: argparse.ArgumentParser,
+) -> None:
+    """Attach the `auth` command group to the top-level subparsers."""
     auth = sub.add_parser(
         "auth",
         help="manage authentication and MFA for your EVNEX account",
@@ -443,25 +400,3 @@ def build_parser() -> argparse.ArgumentParser:
         help="register the device without changing the MFA preference",
     )
     confirm.set_defaults(func=cmd_mfa_confirm)
-
-    return parser
-
-
-def main(argv: list[str] | None = None) -> None:
-    args = build_parser().parse_args(argv)
-    handler = getattr(args, "func", None)
-    if handler is None:
-        # No (leaf) subcommand: print the most specific help and exit cleanly.
-        args.print_group_help()
-        sys.exit(0)
-    try:
-        asyncio.run(handler(args))
-    except EvnexAuthError as err:
-        print(f"Authentication error: {err}", file=sys.stderr)
-        sys.exit(1)
-    except KeyboardInterrupt:
-        sys.exit(130)
-
-
-if __name__ == "__main__":
-    main()

--- a/evnex/cli/_resources.py
+++ b/evnex/cli/_resources.py
@@ -1,0 +1,510 @@
+"""Resource commands: charge point status, sessions, insights, and control.
+
+These commands talk to the EVNEX Cloud API through an authenticated Evnex
+client. Human output is aligned plain text on stdout; with ``--json`` the same
+data is emitted as a single JSON document on stdout (built from the pydantic
+models) while diagnostics stay on stderr.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from typing import NoReturn
+
+import httpx
+
+from evnex.api import Evnex
+from evnex.cli._auth import signed_in_auth
+from evnex.schema.charge_points import EvnexChargePoint
+from evnex.schema.v3.charge_points import EvnexChargePointSession
+
+
+def _positive_int(value: str) -> int:
+    number = int(value)
+    if number < 1:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return number
+
+
+def _abort(message: str, code: int) -> NoReturn:
+    """Print a diagnostic to stderr and exit with the given status."""
+    print(message, file=sys.stderr)
+    sys.exit(code)
+
+
+@asynccontextmanager
+async def open_client(args: argparse.Namespace) -> AsyncIterator[Evnex]:
+    """Sign in and yield an Evnex client, closing its HTTP client on exit."""
+    auth = await signed_in_auth(args)
+    # Building the httpx client loads the CA bundle from disk; do that off the
+    # event loop so the blocking file I/O does not stall it.
+    client = await asyncio.to_thread(Evnex, auth=auth)
+    try:
+        yield client
+    finally:
+        await client.httpx_client.aclose()
+
+
+async def _list_charge_points(client: Evnex) -> list[EvnexChargePoint]:
+    """Fetch the account's charge points (and set the client's org id)."""
+    await client.get_user_detail()
+    # The retry decorator erases the annotated return type to Any; pin it back.
+    charge_points: list[EvnexChargePoint] = await client.get_org_charge_points()
+    return charge_points
+
+
+def _match_charge_point(
+    charge_points: list[EvnexChargePoint], selector: str
+) -> EvnexChargePoint:
+    """Resolve a selector to a single charge point.
+
+    An exact id wins; otherwise the selector is matched case-insensitively as a
+    substring of the name or serial. Zero or multiple matches abort with exit 2.
+    """
+    for charge_point in charge_points:
+        if charge_point.id == selector:
+            return charge_point
+
+    needle = selector.casefold()
+    matches = [
+        charge_point
+        for charge_point in charge_points
+        if needle in charge_point.name.casefold()
+        or needle in charge_point.serial.casefold()
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        _abort(f"No charge point matches {selector!r}", 2)
+    lines = [f"{selector!r} matches several charge points; be more specific:"]
+    lines += [f"  {cp.id}  {cp.name}" for cp in matches]
+    _abort("\n".join(lines), 2)
+
+
+def _resolve_one(
+    charge_points: list[EvnexChargePoint], selector: str | None
+) -> EvnexChargePoint:
+    """Resolve the target charge point, defaulting to the sole one if unique."""
+    if selector is not None:
+        return _match_charge_point(charge_points, selector)
+    if len(charge_points) == 1:
+        return charge_points[0]
+    lines = ["Select a charge point with --charge-point:"]
+    lines += [f"  {cp.id}  {cp.name}" for cp in charge_points]
+    _abort("\n".join(lines), 2)
+
+
+def _kw(watts: float | None) -> str:
+    return "-" if watts is None else f"{watts / 1000:.2f} kW"
+
+
+def _kwh(watt_hours: float | None) -> str:
+    return "-" if watt_hours is None else f"{watt_hours / 1000:.2f} kWh"
+
+
+def _fmt_dt(value: datetime | None) -> str:
+    """Local-readable ISO-8601 with second resolution."""
+    if value is None:
+        return "-"
+    return value.astimezone().replace(microsecond=0).isoformat()
+
+
+def _fmt_period(seconds: float) -> str:
+    """Seconds from midnight as HH:MM."""
+    total_minutes = int(seconds) // 60
+    return f"{total_minutes // 60:02d}:{total_minutes % 60:02d}"
+
+
+def _print_table(headers: list[str], rows: list[list[str]]) -> None:
+    """Print rows as columns padded to a common width."""
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for index, cell in enumerate(row):
+            widths[index] = max(widths[index], len(cell))
+    for row in [headers, *rows]:
+        print("  ".join(cell.ljust(widths[index]) for index, cell in enumerate(row)))
+
+
+def _latest_session(
+    sessions: list[EvnexChargePointSession],
+) -> EvnexChargePointSession | None:
+    ordered = _newest_first(sessions)
+    return ordered[0] if ordered else None
+
+
+def _newest_first(
+    sessions: list[EvnexChargePointSession],
+) -> list[EvnexChargePointSession]:
+    # The API does not document an ordering; sort rather than assume one
+    epoch = datetime.min.replace(tzinfo=UTC)
+    return sorted(sessions, key=lambda s: s.attributes.startDate or epoch, reverse=True)
+
+
+async def cmd_live_status(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        charge_points = await _list_charge_points(client)
+        if args.charge_point is not None:
+            targets = [_match_charge_point(charge_points, args.charge_point)]
+        else:
+            targets = charge_points
+
+        payload = []
+        blocks: list[list[str]] = []
+        for charge_point in targets:
+            detail = await client.get_charge_point_detail_v3(charge_point.id)
+            sessions = await client.get_charge_point_sessions(charge_point.id)
+            attributes = detail.data.attributes
+            latest = _latest_session(sessions)
+
+            if args.json:
+                payload.append(
+                    {
+                        "chargePoint": attributes.model_dump(mode="json"),
+                        "sessions": [s.model_dump(mode="json") for s in sessions],
+                    }
+                )
+                continue
+
+            lines = [f"{attributes.name} ({attributes.serial})"]
+            lines.append(f"  Network: {attributes.networkStatus}")
+            for connector in attributes.connectors:
+                lines.append(
+                    f"  Connector {connector.connectorId}: {connector.ocppStatus}"
+                )
+                if connector.meter is not None:
+                    lines.append(f"    Charging power: {_kw(connector.meter.power)}")
+                    if connector.meter.supplyActivePower is not None:
+                        lines.append(
+                            f"    Grid power: {_kw(connector.meter.supplyActivePower)}"
+                        )
+            if latest is not None and latest.attributes.endDate is None:
+                session = latest.attributes
+                summary = f"  Active session: {_kwh(session.totalPowerUsage)}"
+                if session.totalCost is not None:
+                    summary += (
+                        f", {session.totalCost.amount:.2f} {session.totalCost.currency}"
+                    )
+                lines.append(summary)
+            blocks.append(lines)
+
+        if args.json:
+            print(json.dumps(payload, indent=2))
+            return
+        if not blocks:
+            print("No charge points found", file=sys.stderr)
+            return
+        print("\n\n".join("\n".join(block) for block in blocks))
+
+
+async def cmd_charge_points_list(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        charge_points = await _list_charge_points(client)
+        if args.json:
+            print(
+                json.dumps(
+                    [cp.model_dump(mode="json") for cp in charge_points], indent=2
+                )
+            )
+            return
+        rows = [[cp.id, cp.name, cp.serial, cp.networkStatus] for cp in charge_points]
+        _print_table(["ID", "Name", "Serial", "Network"], rows)
+
+
+async def cmd_charge_points_show(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        charge_points = await _list_charge_points(client)
+        charge_point = _resolve_one(charge_points, args.charge_point)
+        detail = await client.get_charge_point_detail_v3(charge_point.id)
+        attributes = detail.data.attributes
+
+        if args.json:
+            print(json.dumps(attributes.model_dump(mode="json"), indent=2))
+            return
+
+        print(f"{attributes.name} ({attributes.serial})")
+        print(f"  Model: {attributes.model}")
+        print(f"  Firmware: {attributes.firmware}")
+        print(f"  Serial: {attributes.serial}")
+        print(f"  Network status: {attributes.networkStatus}")
+        for connector in attributes.connectors:
+            print(
+                f"  Connector {connector.connectorId} "
+                f"({connector.connectorType}): {connector.ocppStatus}"
+            )
+            if connector.meter is not None:
+                print(f"    Charging power: {_kw(connector.meter.power)}")
+                if connector.meter.supplyActivePower is not None:
+                    print(f"    Grid power: {_kw(connector.meter.supplyActivePower)}")
+        schedule = attributes.profiles.chargeSchedule
+        enabled = "enabled" if schedule is not None and schedule.enabled else "disabled"
+        print(f"  Charge schedule: {enabled}")
+
+
+async def cmd_sessions_list(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        charge_points = await _list_charge_points(client)
+        charge_point = _resolve_one(charge_points, args.charge_point)
+        sessions = await client.get_charge_point_sessions(charge_point.id)
+        sessions = _newest_first(sessions)[: args.limit]
+
+        if args.json:
+            print(json.dumps([s.model_dump(mode="json") for s in sessions], indent=2))
+            return
+
+        rows = []
+        for session in sessions:
+            attributes = session.attributes
+            end = (
+                "active" if attributes.endDate is None else _fmt_dt(attributes.endDate)
+            )
+            cost = "-"
+            if attributes.totalCost is not None:
+                cost = (
+                    f"{attributes.totalCost.amount:.2f} {attributes.totalCost.currency}"
+                )
+            rows.append(
+                [
+                    _fmt_dt(attributes.startDate),
+                    end,
+                    _kwh(attributes.totalPowerUsage),
+                    cost,
+                ]
+            )
+        _print_table(["Start", "End", "Energy", "Cost"], rows)
+
+
+async def cmd_insights(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        await client.get_user_detail()
+        insights = await client.get_org_insight(days=args.days)
+
+        if args.json:
+            print(json.dumps([i.model_dump(mode="json") for i in insights], indent=2))
+            return
+
+        rows = []
+        for entry in insights:
+            cost = "-"
+            if entry.cost.cost is not None:
+                cost = f"{entry.cost.cost:.2f} {entry.cost.currency or ''}".strip()
+            rows.append(
+                [
+                    entry.startDate.strftime("%Y-%m-%d"),
+                    _kwh(entry.powerUsage),
+                    cost,
+                    str(entry.sessions),
+                ]
+            )
+        _print_table(["Date", "Energy", "Cost", "Sessions"], rows)
+
+
+async def cmd_charge_now(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        charge_points = await _list_charge_points(client)
+        charge_point = _resolve_one(charge_points, args.charge_point)
+        await client.set_charge_point_override(charge_point.id, charge_now=True)
+        print(f"Charging now on {charge_point.name} ({charge_point.serial})")
+
+
+async def cmd_charge_auto(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        charge_points = await _list_charge_points(client)
+        charge_point = _resolve_one(charge_points, args.charge_point)
+        await client.set_charge_point_override(charge_point.id, charge_now=False)
+        print(
+            f"Returned {charge_point.name} ({charge_point.serial}) "
+            "to its charging schedule"
+        )
+
+
+async def cmd_charge_stop(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        charge_points = await _list_charge_points(client)
+        charge_point = _resolve_one(charge_points, args.charge_point)
+        if not args.yes:
+            # See the module note: blocking on input() is fine for this CLI.
+            answer = input(
+                f"Stop the active charging session on {charge_point.name}? [y/N] "
+            )
+            if answer.strip().lower() not in ("y", "yes"):
+                _abort("Aborted.", 1)
+        try:
+            await client.stop_charge_point(charge_point.id)
+        except httpx.ReadTimeout:
+            # The API answers a stop with no active session as a 504 that
+            # surfaces as a read timeout.
+            _abort(f"No active charging session on {charge_point.name} to stop.", 1)
+        print(f"Stopped charging on {charge_point.name} ({charge_point.serial})")
+
+
+async def cmd_schedule_show(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        charge_points = await _list_charge_points(client)
+        charge_point = _resolve_one(charge_points, args.charge_point)
+        detail = await client.get_charge_point_detail_v3(charge_point.id)
+        schedule = detail.data.attributes.profiles.chargeSchedule
+
+        if args.json:
+            dumped = None if schedule is None else schedule.model_dump(mode="json")
+            print(json.dumps(dumped, indent=2))
+            return
+
+        if schedule is None:
+            print(f"No charge schedule configured for {charge_point.name}")
+            return
+        print(
+            f"Charge schedule for {charge_point.name}: "
+            f"{'enabled' if schedule.enabled else 'disabled'}"
+        )
+        for period in schedule.chargingSchedulePeriods:
+            print(f"  {_fmt_period(period.startPeriod)}  {period.limit:g} A")
+
+
+def add_resource_commands(
+    sub: argparse._SubParsersAction,
+    cache_flags: argparse.ArgumentParser,
+    otp_flags: argparse.ArgumentParser,
+) -> None:
+    """Attach the resource command groups to the top-level subparsers."""
+    sign_in = [cache_flags, otp_flags]
+
+    json_flag = argparse.ArgumentParser(add_help=False)
+    json_flag.add_argument(
+        "--json",
+        action="store_true",
+        help="emit machine-readable JSON on stdout",
+    )
+    cp_flag = argparse.ArgumentParser(add_help=False)
+    cp_flag.add_argument(
+        "--charge-point",
+        metavar="ID",
+        help="charge point id, or a part of its name or serial of its name or serial",
+    )
+
+    status = sub.add_parser(
+        "status",
+        parents=[cp_flag, json_flag, *sign_in],
+        help="show a live view of your charge points",
+        description=(
+            "Show, for each charge point (or the one selected with "
+            "--charge-point), its network status, each connector's status and "
+            "power, and any active charging session's energy and cost."
+        ),
+    )
+    status.set_defaults(func=cmd_live_status)
+
+    charge_points = sub.add_parser(
+        "charge-points",
+        help="list and inspect charge points",
+        description="List charge points or show the detail of one.",
+    )
+    charge_points.set_defaults(print_group_help=charge_points.print_help)
+    charge_points_sub = charge_points.add_subparsers(dest="charge_points_command")
+
+    cp_list = charge_points_sub.add_parser(
+        "list",
+        parents=[json_flag, *sign_in],
+        help="list charge points (id, name, serial, network status)",
+    )
+    cp_list.set_defaults(func=cmd_charge_points_list)
+
+    cp_show = charge_points_sub.add_parser(
+        "show",
+        parents=[json_flag, *sign_in],
+        help="show the detail of one charge point",
+    )
+    cp_show.add_argument(
+        "charge_point",
+        nargs="?",
+        metavar="ID",
+        help="charge point id, or a part of its name or serial of its name or serial",
+    )
+    cp_show.set_defaults(func=cmd_charge_points_show)
+
+    sessions = sub.add_parser(
+        "sessions",
+        help="list charging sessions",
+        description="List recent charging sessions for a charge point.",
+    )
+    sessions.set_defaults(print_group_help=sessions.print_help)
+    sessions_sub = sessions.add_subparsers(dest="sessions_command")
+
+    sessions_list = sessions_sub.add_parser(
+        "list",
+        parents=[cp_flag, json_flag, *sign_in],
+        help="list recent charging sessions for a charge point",
+    )
+    sessions_list.add_argument(
+        "--limit",
+        type=_positive_int,
+        default=10,
+        help="maximum number of sessions to show (default 10)",
+    )
+    sessions_list.set_defaults(func=cmd_sessions_list)
+
+    insights = sub.add_parser(
+        "insights",
+        parents=[json_flag, *sign_in],
+        help="show daily energy, cost, and session counts for the organisation",
+    )
+    insights.add_argument(
+        "--days",
+        type=int,
+        choices=(7, 14, 30),
+        default=7,
+        help="reporting window in days (default 7)",
+    )
+    insights.set_defaults(func=cmd_insights)
+
+    charge = sub.add_parser(
+        "charge",
+        help="control charging on a charge point",
+        description="Start charging now, return to the schedule, or stop charging.",
+    )
+    charge.set_defaults(print_group_help=charge.print_help)
+    charge_sub = charge.add_subparsers(dest="charge_command")
+
+    charge_now = charge_sub.add_parser(
+        "now",
+        parents=[cp_flag, *sign_in],
+        help="start charging immediately, overriding the schedule",
+    )
+    charge_now.set_defaults(func=cmd_charge_now)
+
+    charge_auto = charge_sub.add_parser(
+        "auto",
+        parents=[cp_flag, *sign_in],
+        help="return control to the configured charging schedule",
+    )
+    charge_auto.set_defaults(func=cmd_charge_auto)
+
+    charge_stop = charge_sub.add_parser(
+        "stop",
+        parents=[cp_flag, *sign_in],
+        help="stop the active charging session",
+    )
+    charge_stop.add_argument(
+        "--yes", "-y", action="store_true", help="skip the confirmation prompt"
+    )
+    charge_stop.set_defaults(func=cmd_charge_stop)
+
+    schedule = sub.add_parser(
+        "schedule",
+        help="view the charging schedule",
+        description="Show the charging schedule configured on a charge point.",
+    )
+    schedule.set_defaults(print_group_help=schedule.print_help)
+    schedule_sub = schedule.add_subparsers(dest="schedule_command")
+
+    schedule_show = schedule_sub.add_parser(
+        "show",
+        parents=[cp_flag, json_flag, *sign_in],
+        help="show the charging schedule (enabled state and periods)",
+    )
+    schedule_show.set_defaults(func=cmd_schedule_show)

--- a/evnex/schema/org.py
+++ b/evnex/schema/org.py
@@ -24,6 +24,8 @@ class EvnexOrgInsightEntry(BaseModel):
     carbonUsage: float | None = None
     cost: EvnexCost
     duration: int
+    # Watt-hours, like all energy figures in this API (the official app
+    # and integrations render these via Wh sensors)
     powerUsage: float
     sessions: int
     startDate: datetime

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -157,7 +157,7 @@ class TestPasswordMismatch:
         async def fake_signed_in(args):
             return FakeAuth()
 
-        monkeypatch.setattr("evnex.cli.signed_in_auth", fake_signed_in)
+        monkeypatch.setattr("evnex.cli._auth.signed_in_auth", fake_signed_in)
         prompts = iter(["current", "new-one", "new-two"])
         monkeypatch.setattr("getpass.getpass", lambda *a, **k: next(prompts))
 
@@ -178,7 +178,7 @@ class TestPasswordMismatch:
             async def confirm_password_reset(self, *args):
                 raise AssertionError("reset must not run after mismatch")
 
-        monkeypatch.setattr("evnex.cli.EvnexAuth", FakeAuth)
+        monkeypatch.setattr("evnex.cli._auth.EvnexAuth", FakeAuth)
         monkeypatch.setenv("EVNEX_CLIENT_USERNAME", "user@example.com")
         monkeypatch.setattr("builtins.input", lambda *a, **k: "123456")
         prompts = iter(["new-one", "new-two"])

--- a/tests/test_cli_resources.py
+++ b/tests/test_cli_resources.py
@@ -1,0 +1,724 @@
+"""Tests for the CLI resource commands: parser wiring, charge-point
+resolution, per-command behaviour against mocked API responses, and JSON
+output purity.
+
+HTTP is mocked with respx; sign-in is replaced with a resumed offline auth so
+no credentials or network are needed. The payloads below validate against the
+real pydantic response models (see test_fixtures_validate_against_models).
+"""
+
+import asyncio
+import json
+
+import httpx
+import pytest
+import respx
+
+from evnex.cli import _resources, build_parser
+from evnex.cli._resources import _match_charge_point, _resolve_one
+from evnex.schema.charge_points import EvnexGetChargePointsResponse
+from evnex.schema.org import EvnexGetOrgInsights
+from evnex.schema.user import EvnexGetUserResponse
+from evnex.schema.v3.charge_points import (
+    EvnexChargePointDetail as EvnexChargePointDetailV3,
+)
+from evnex.schema.v3.charge_points import EvnexGetChargePointSessionsResponse
+from evnex.schema.v3.generic import EvnexV3APIResponse
+
+BASE = "https://client-api.evnex.io"
+USER_URL = f"{BASE}/v2/apps/user"
+CP_URL = f"{BASE}/v2/apps/organisations/org-0000/charge-points"
+DETAIL_URL = f"{BASE}/charge-points/cp-0000001"
+SESSIONS_URL = f"{BASE}/charge-points/cp-0000001/sessions"
+INSIGHTS_URL = f"{BASE}/organisations/org-0000/summary/insights"
+OVERRIDE_URL = f"{BASE}/charge-points/cp-0000001/commands/set-override"
+STOP_URL = (
+    f"{BASE}/v2/apps/organisations/org-0000"
+    "/charge-points/cp-0000001/commands/remote-stop-transaction"
+)
+
+USER_PAYLOAD = {
+    "data": {
+        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "createdDate": "2024-01-01T00:00:00Z",
+        "updatedDate": "2024-01-01T00:00:00Z",
+        "name": "Test User",
+        "email": "user@example.com",
+        "organisations": [
+            {
+                "id": "org-0000",
+                "isDefault": True,
+                "role": 1,
+                "createdDate": "2024-01-01T00:00:00Z",
+                "name": "Test Org",
+                "slug": "test-org",
+                "tier": 1,
+                "updatedDate": "2024-01-01T00:00:00Z",
+            }
+        ],
+        "type": "User",
+    }
+}
+
+
+def _charge_point_item(cp_id, name, serial):
+    return {
+        "id": cp_id,
+        "createdDate": "2024-01-01T00:00:00Z",
+        "updatedDate": "2024-06-01T00:00:00Z",
+        "networkStatusUpdatedDate": "2024-06-01T00:00:00Z",
+        "name": name,
+        "ocppChargePointId": serial,
+        "serial": serial,
+        "networkStatus": "ONLINE",
+        "location": {
+            "id": "loc-0000001",
+            "name": "Home",
+            "createdDate": "2024-01-01T00:00:00Z",
+            "updatedDate": "2024-01-01T00:00:00Z",
+            "address": {
+                "address1": "1 Test Street",
+                "city": "Wellington",
+                "postCode": "6011",
+                "country": "NZ",
+            },
+            "coordinates": {"latitude": -41.2865, "longitude": 174.7762},
+            "chargePointCount": 1,
+        },
+        "details": {"model": "E2", "vendor": "Evnex", "firmware": "1.2.3"},
+        "connectors": [
+            {
+                "powerType": "AC_1_PHASE",
+                "connectorId": "1",
+                "evseId": "1",
+                "updatedDate": "2024-06-01T00:00:00Z",
+                "connectorType": "TYPE_2_SOCKET",
+                "amperage": 32,
+                "voltage": 230,
+                "connectorFormat": "CABLE",
+                "ocppStatus": "AVAILABLE",
+                "status": "AVAILABLE",
+                "ocppCode": "NoError",
+                "meter": {
+                    "powerType": "AC_1_PHASE",
+                    "updatedDate": "2024-06-01T00:00:00Z",
+                    "power": 0,
+                    "register": 12345.6,
+                    "frequency": 50,
+                },
+            }
+        ],
+        "lastHeard": "2024-06-01T00:00:00Z",
+        "maxCurrent": 32,
+        "tokenRequired": False,
+        "needsRegistrationInformation": False,
+    }
+
+
+CHARGE_POINTS_PAYLOAD = {
+    "data": {"items": [_charge_point_item("cp-0000001", "Garage Charger", "SN0000001")]}
+}
+
+TWO_CHARGE_POINTS_PAYLOAD = {
+    "data": {
+        "items": [
+            _charge_point_item("cp-0000001", "Garage Charger", "SN0000001"),
+            _charge_point_item("cp-0000002", "Driveway Charger", "SN0000002"),
+        ]
+    }
+}
+
+DETAIL_V3_PAYLOAD = {
+    "data": {
+        "id": "cp-0000001",
+        "type": "chargePoint",
+        "attributes": {
+            "connectors": [
+                {
+                    "evseId": "1",
+                    "connectorFormat": "CABLE",
+                    "connectorType": "TYPE_2_SOCKET",
+                    "ocppStatus": "CHARGING",
+                    "powerType": "AC_1_PHASE",
+                    "connectorId": "1",
+                    "ocppCode": "CHARGING",
+                    "updatedDate": "2024-06-01T00:00:00Z",
+                    "meter": {
+                        "currentL1": 16,
+                        "frequency": 50,
+                        "power": 3600,
+                        "register": 12345.6,
+                        "supplyActivePower": 400,
+                        "updatedDate": "2024-06-01T00:00:00Z",
+                        "voltageL1N": 230,
+                    },
+                    "maxVoltage": 230,
+                    "maxAmperage": 32,
+                }
+            ],
+            "createdDate": "2024-01-01T00:00:00Z",
+            "electricityCost": {
+                "currency": "NZD",
+                "tariffs": [{"start": 0, "rate": 0.28, "type": "Flat"}],
+                "tariffType": "Flat",
+                "cost": 0.28,
+            },
+            "firmware": "1.2.3",
+            "maxCurrent": 32,
+            "model": "E2",
+            "name": "Garage Charger",
+            "networkStatus": "ONLINE",
+            "networkStatusUpdatedDate": "2024-06-01T00:00:00Z",
+            "ocppChargePointId": "SN0000001",
+            "profiles": {
+                "chargeSchedule": {
+                    "enabled": True,
+                    "chargingSchedulePeriods": [
+                        {"limit": 32, "startPeriod": 0},
+                        {"limit": 0, "startPeriod": 79200},
+                    ],
+                }
+            },
+            "serial": "SN0000001",
+            "timeZone": "Pacific/Auckland",
+            "tokenRequired": False,
+            "updatedDate": "2024-06-01T00:00:00Z",
+            "vendor": "Evnex",
+        },
+        "relationships": {
+            "chargePoint": None,
+            "location": {"data": {"id": "loc-0000001", "type": "location"}},
+            "organisation": {"data": {"id": "org-0000", "type": "organisation"}},
+        },
+    },
+    "included": None,
+}
+
+SESSIONS_PAYLOAD = {
+    "data": [
+        {
+            "id": "session-0000001",
+            "type": "session",
+            "attributes": {
+                "connectorId": "1",
+                "createdDate": "2024-06-02T08:00:00Z",
+                "evseId": "1",
+                "sessionStatus": "InProgress",
+                "startDate": "2024-06-02T08:00:00Z",
+                "updatedDate": "2024-06-02T08:30:00Z",
+                "endDate": None,
+                "totalPowerUsage": 3500,
+                "totalCost": None,
+            },
+        },
+        {
+            "id": "session-0000002",
+            "type": "session",
+            "attributes": {
+                "connectorId": "1",
+                "createdDate": "2024-06-01T08:00:00Z",
+                "evseId": "1",
+                "sessionStatus": "Completed",
+                "startDate": "2024-06-01T08:00:00Z",
+                "updatedDate": "2024-06-01T09:00:00Z",
+                "endDate": "2024-06-01T09:00:00Z",
+                "totalPowerUsage": 7000,
+                "totalCost": {"currency": "NZD", "amount": 1.96, "distribution": None},
+            },
+        },
+    ]
+}
+
+INSIGHTS_PAYLOAD = {
+    "data": [
+        {
+            "attributes": {
+                "carbonOffset": 1.1,
+                "carbonUsage": 0.9,
+                "cost": {"currency": "NZD", "cost": 1.5},
+                "duration": 3600,
+                "powerUsage": 1000,
+                "sessions": 1,
+                "startDate": "2024-06-10T00:00:00Z",
+            }
+        },
+        {
+            "attributes": {
+                "carbonOffset": 1.1,
+                "carbonUsage": 0.9,
+                "cost": {"currency": "NZD", "cost": 2.5},
+                "duration": 7200,
+                "powerUsage": 2000,
+                "sessions": 2,
+                "startDate": "2024-06-11T00:00:00Z",
+            }
+        },
+    ]
+}
+
+
+@pytest.fixture
+def cli(resumed_auth, monkeypatch):
+    """Patch sign-in so resource handlers use the offline resumed session."""
+
+    async def fake_signed_in(args):
+        return resumed_auth
+
+    monkeypatch.setattr("evnex.cli._resources.signed_in_auth", fake_signed_in)
+    return resumed_auth
+
+
+async def run(argv):
+    """Parse argv and invoke the resolved leaf handler.
+
+    Parsing happens in a worker thread because build_parser() reads package
+    metadata from disk; production parses before entering the event loop.
+    """
+    args = await asyncio.to_thread(lambda: build_parser().parse_args(argv))
+    await args.func(args)
+
+
+def _charge_points(payload):
+    return EvnexGetChargePointsResponse.model_validate(payload).data.items
+
+
+# --- Fixture fidelity -----------------------------------------------------
+
+
+def test_fixtures_validate_against_models():
+    EvnexGetUserResponse.model_validate(USER_PAYLOAD)
+    EvnexGetChargePointsResponse.model_validate(CHARGE_POINTS_PAYLOAD)
+    detail = EvnexV3APIResponse[EvnexChargePointDetailV3].model_validate(
+        DETAIL_V3_PAYLOAD
+    )
+    # The JSON key is 'register'; the python attribute is raw_register
+    assert detail.data.attributes.connectors[0].meter.raw_register == 12345.6
+    sessions = EvnexGetChargePointSessionsResponse.model_validate(SESSIONS_PAYLOAD)
+    assert sessions.data[0].attributes.endDate is None
+    insights = EvnexGetOrgInsights.model_validate(INSIGHTS_PAYLOAD)
+    assert insights.data[0].attributes.sessions == 1
+
+
+# --- Parser wiring --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "func_name, argv",
+    [
+        ("cmd_live_status", ["status"]),
+        ("cmd_live_status", ["status", "--charge-point", "cp-1", "--json"]),
+        ("cmd_charge_points_list", ["charge-points", "list"]),
+        ("cmd_charge_points_list", ["charge-points", "list", "--json"]),
+        ("cmd_charge_points_show", ["charge-points", "show"]),
+        ("cmd_charge_points_show", ["charge-points", "show", "cp-1", "--json"]),
+        ("cmd_sessions_list", ["sessions", "list"]),
+        (
+            "cmd_sessions_list",
+            ["sessions", "list", "--charge-point", "cp-1", "--limit", "5", "--json"],
+        ),
+        ("cmd_insights", ["insights"]),
+        ("cmd_insights", ["insights", "--days", "14", "--json"]),
+        ("cmd_charge_now", ["charge", "now", "--charge-point", "cp-1"]),
+        ("cmd_charge_auto", ["charge", "auto"]),
+        ("cmd_charge_stop", ["charge", "stop", "--yes"]),
+        ("cmd_charge_stop", ["charge", "stop", "-y"]),
+        ("cmd_schedule_show", ["schedule", "show"]),
+        ("cmd_schedule_show", ["schedule", "show", "--charge-point", "cp-1", "--json"]),
+    ],
+)
+def test_resource_leaf_dispatch(func_name, argv):
+    args = build_parser().parse_args(argv)
+    assert args.func is getattr(_resources, func_name)
+
+
+def test_shared_flags_accepted_in_trailing_position():
+    args = build_parser().parse_args(
+        ["status", "--json", "--otp", "123456", "--token-cache", "/tmp/tokens.json"]
+    )
+    assert args.json is True
+    assert args.otp == "123456"
+    assert str(args.token_cache) == "/tmp/tokens.json"
+
+
+def test_sessions_limit_defaults_to_ten():
+    args = build_parser().parse_args(["sessions", "list"])
+    assert args.limit == 10
+
+
+def test_insights_days_defaults_to_seven():
+    args = build_parser().parse_args(["insights"])
+    assert args.days == 7
+
+
+def test_insights_rejects_unsupported_days():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["insights", "--days", "3"])
+
+
+# --- Charge-point resolution ----------------------------------------------
+
+
+def test_resolve_single_charge_point_by_default():
+    charge_points = _charge_points(CHARGE_POINTS_PAYLOAD)
+    assert _resolve_one(charge_points, None).id == "cp-0000001"
+
+
+def test_resolve_ambiguous_default_exits_2(capsys):
+    charge_points = _charge_points(TWO_CHARGE_POINTS_PAYLOAD)
+    with pytest.raises(SystemExit) as exc:
+        _resolve_one(charge_points, None)
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "Select a charge point" in err
+    assert "cp-0000001" in err and "cp-0000002" in err
+
+
+def test_resolve_prefix_match_by_name():
+    charge_points = _charge_points(TWO_CHARGE_POINTS_PAYLOAD)
+    assert _resolve_one(charge_points, "garage").name == "Garage Charger"
+
+
+def test_resolve_match_by_serial():
+    charge_points = _charge_points(TWO_CHARGE_POINTS_PAYLOAD)
+    assert _match_charge_point(charge_points, "sn0000002").id == "cp-0000002"
+
+
+def test_resolve_exact_id_wins():
+    charge_points = _charge_points(TWO_CHARGE_POINTS_PAYLOAD)
+    assert _match_charge_point(charge_points, "cp-0000002").id == "cp-0000002"
+
+
+def test_resolve_ambiguous_selector_exits_2(capsys):
+    charge_points = _charge_points(TWO_CHARGE_POINTS_PAYLOAD)
+    with pytest.raises(SystemExit) as exc:
+        _match_charge_point(charge_points, "charger")
+    assert exc.value.code == 2
+    assert "be more specific" in capsys.readouterr().err
+
+
+def test_resolve_unknown_selector_exits_2(capsys):
+    charge_points = _charge_points(CHARGE_POINTS_PAYLOAD)
+    with pytest.raises(SystemExit) as exc:
+        _match_charge_point(charge_points, "nonexistent")
+    assert exc.value.code == 2
+    assert "No charge point matches" in capsys.readouterr().err
+
+
+# --- Command behaviour ----------------------------------------------------
+
+
+async def test_status_shows_power_and_active_session(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(DETAIL_URL).mock(
+            return_value=httpx.Response(200, json=DETAIL_V3_PAYLOAD)
+        )
+        respx.get(SESSIONS_URL).mock(
+            return_value=httpx.Response(200, json=SESSIONS_PAYLOAD)
+        )
+        await run(["status"])
+
+    out = capsys.readouterr().out
+    assert "Garage Charger (SN0000001)" in out
+    assert "Network: ONLINE" in out
+    assert "Connector 1: CHARGING" in out
+    assert "Charging power: 3.60 kW" in out
+    assert "Grid power: 0.40 kW" in out
+    assert "Active session: 3.50 kWh" in out
+
+
+async def test_status_json_is_the_only_thing_on_stdout(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(DETAIL_URL).mock(
+            return_value=httpx.Response(200, json=DETAIL_V3_PAYLOAD)
+        )
+        respx.get(SESSIONS_URL).mock(
+            return_value=httpx.Response(200, json=SESSIONS_PAYLOAD)
+        )
+        await run(["status", "--json"])
+
+    captured = capsys.readouterr()
+    # The whole of stdout must parse as a single JSON document
+    payload = json.loads(captured.out)
+    assert payload[0]["chargePoint"]["serial"] == "SN0000001"
+    assert payload[0]["sessions"][0]["id"] == "session-0000001"
+
+
+async def test_charge_points_list(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        await run(["charge-points", "list"])
+
+    out = capsys.readouterr().out
+    assert "cp-0000001" in out
+    assert "Garage Charger" in out
+    assert "SN0000001" in out
+    assert "ONLINE" in out
+
+
+async def test_charge_points_show(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(DETAIL_URL).mock(
+            return_value=httpx.Response(200, json=DETAIL_V3_PAYLOAD)
+        )
+        await run(["charge-points", "show"])
+
+    out = capsys.readouterr().out
+    assert "Model: E2" in out
+    assert "Firmware: 1.2.3" in out
+    assert "Charge schedule: enabled" in out
+
+
+async def test_sessions_list(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(SESSIONS_URL).mock(
+            return_value=httpx.Response(200, json=SESSIONS_PAYLOAD)
+        )
+        await run(["sessions", "list"])
+
+    out = capsys.readouterr().out
+    assert "active" in out  # the in-progress session has no end date
+    assert "7.00 kWh" in out
+    assert "1.96 NZD" in out
+
+
+async def test_sessions_list_respects_limit(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(SESSIONS_URL).mock(
+            return_value=httpx.Response(200, json=SESSIONS_PAYLOAD)
+        )
+        await run(["sessions", "list", "--limit", "1"])
+
+    out = capsys.readouterr().out
+    # Header plus exactly one data row
+    assert len(out.strip().splitlines()) == 2
+    assert "1.96 NZD" not in out
+
+
+async def test_insights(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(INSIGHTS_URL, params={"days": 7, "tz-offset": 12}).mock(
+            return_value=httpx.Response(200, json=INSIGHTS_PAYLOAD)
+        )
+        await run(["insights"])
+
+    out = capsys.readouterr().out
+    assert "2024-06-10" in out
+    assert "1.00 kWh" in out
+    assert "1.50 NZD" in out
+
+
+async def test_charge_now_sends_override(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        route = respx.post(OVERRIDE_URL).mock(return_value=httpx.Response(200, json={}))
+        await run(["charge", "now"])
+
+    out = capsys.readouterr().out
+    assert "Charging now on Garage Charger" in out
+    assert json.loads(route.calls[0].request.content)["chargeNow"] is True
+
+
+async def test_charge_auto_sends_override(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        route = respx.post(OVERRIDE_URL).mock(return_value=httpx.Response(200, json={}))
+        await run(["charge", "auto"])
+
+    out = capsys.readouterr().out
+    assert "charging schedule" in out
+    assert json.loads(route.calls[0].request.content)["chargeNow"] is False
+
+
+async def test_charge_stop(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.post(STOP_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"message": "Command accepted", "status": "Accepted"}},
+            )
+        )
+        await run(["charge", "stop", "--yes"])
+
+    assert "Stopped charging on Garage Charger" in capsys.readouterr().out
+
+
+async def test_charge_stop_no_active_session_exits_1(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.post(STOP_URL).mock(side_effect=httpx.ReadTimeout("timeout"))
+        with pytest.raises(SystemExit) as exc:
+            await run(["charge", "stop", "--yes"])
+
+    assert exc.value.code == 1
+    assert "No active charging session" in capsys.readouterr().err
+
+
+async def test_schedule_show(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(DETAIL_URL).mock(
+            return_value=httpx.Response(200, json=DETAIL_V3_PAYLOAD)
+        )
+        await run(["schedule", "show"])
+
+    out = capsys.readouterr().out
+    assert "Charge schedule for Garage Charger: enabled" in out
+    assert "00:00" in out
+    assert "22:00" in out
+    assert "32 A" in out
+
+
+async def test_schedule_show_json(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(DETAIL_URL).mock(
+            return_value=httpx.Response(200, json=DETAIL_V3_PAYLOAD)
+        )
+        await run(["schedule", "show", "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["enabled"] is True
+    assert payload["chargingSchedulePeriods"][0]["limit"] == 32
+
+
+async def test_charge_stop_declined_prompt_aborts(cli, capsys, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        stop = respx.post(STOP_URL)
+        with pytest.raises(SystemExit) as exc:
+            await run(["charge", "stop"])
+
+    assert exc.value.code == 1
+    assert "Aborted" in capsys.readouterr().err
+    assert stop.call_count == 0  # the command was never sent
+
+
+async def test_charge_stop_accepted_prompt_sends_command(cli, capsys, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        stop = respx.post(STOP_URL).mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": {"message": "Command accepted", "status": "Accepted"}},
+            )
+        )
+        await run(["charge", "stop"])
+
+    assert stop.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["charge-points", "list", "--json"],
+        ["sessions", "list", "--json"],
+        ["insights", "--json"],
+    ],
+)
+async def test_json_purity_on_listings(cli, capsys, argv):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(SESSIONS_URL).mock(
+            return_value=httpx.Response(200, json=SESSIONS_PAYLOAD)
+        )
+        respx.get(INSIGHTS_URL).mock(
+            return_value=httpx.Response(200, json=INSIGHTS_PAYLOAD)
+        )
+        await run(argv)
+
+    out = capsys.readouterr().out
+    json.loads(out)  # stdout is exactly one JSON document
+
+
+async def test_sessions_ordering_is_enforced(cli, capsys):
+    # Serve the sessions oldest-first; the CLI must still show newest first
+    reversed_payload = {"data": list(reversed(SESSIONS_PAYLOAD["data"]))}
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(SESSIONS_URL).mock(
+            return_value=httpx.Response(200, json=reversed_payload)
+        )
+        await run(["sessions", "list", "--limit", "1"])
+
+    out = capsys.readouterr().out
+    assert "active" in out  # the newest (active) session, not the oldest
+
+
+async def test_status_renders_charge_point_without_meter(cli, capsys):
+    detail = json.loads(json.dumps(DETAIL_V3_PAYLOAD))
+    detail["data"]["attributes"]["connectors"][0]["meter"] = None
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(CP_URL).mock(
+            return_value=httpx.Response(200, json=CHARGE_POINTS_PAYLOAD)
+        )
+        respx.get(DETAIL_URL).mock(return_value=httpx.Response(200, json=detail))
+        respx.get(SESSIONS_URL).mock(
+            return_value=httpx.Response(200, json=SESSIONS_PAYLOAD)
+        )
+        await run(["status"])
+
+    out = capsys.readouterr().out
+    assert "Garage Charger" in out  # renders, no crash, no meter lines
+
+
+def test_sessions_limit_must_be_positive():
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["sessions", "list", "--limit", "-1"])


### PR DESCRIPTION
Implements the resource commands from #116 on top of the 0.7.0 CLI:

```
evnex status [--charge-point ID]      # live view: connectors, charging power, grid power, active session
evnex charge-points list | show [ID]
evnex sessions list [--limit N]
evnex insights [--days 7|14|30]
evnex charge now | auto | stop        # override on, back to schedule, stop session
evnex schedule show
```

- `--json` on `status`, the listings, `insights`, and `schedule show` — exactly one JSON document on stdout, built from the pydantic models.
- Charge point selection: `--charge-point` matches id, or part of the name/serial (case-insensitive); a single-charger account needs no flag; ambiguity errors with the candidates, exit 2.
- `charge stop` keeps its confirmation prompt (`--yes` to skip) and maps the API's timeout-when-idle behaviour to a clear message. State-changing commands never retry on HTTP errors.
- `evnex/cli.py` split into a package (`_auth`, `_resources`) with the entry point unchanged.
- 137 tests: fixtures proven against the real schemas, JSON purity, resolution rules, the stop-confirmation interlock, enforced session ordering, meter-less rendering.

Built with a research → implement → adversarial-review agent workflow; all review findings addressed (session ordering enforced rather than assumed, friendly transport-error handling, unit documentation at the schema, positive-limit guard, namespace collision rename).

**Live-validated against a real account and charger**: MFA sign-in via --otp, every read command (status with live grid power from the CT, charge-points list, sessions list with real charges — 50.92 kWh / $9.16 NZD confirming the unit conversions with production data, insights, schedule show), and the write path: `evnex charge now` accepted by the API with the charger subsequently drawing 7.29 kW and the active session visible in `status`.

