### PR TITLE
Wrap organisation locations and connector summary endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ uvx evnex status                     # live view: connectors, power, sessions
 uvx evnex charge-points list         # id, name, serial, network status
 uvx evnex charge-points show         # detail for one charge point
 uvx evnex sessions list              # recent charging sessions
+uvx evnex locations list             # name, city, ICP number, retailer, timezone
 uvx evnex insights                   # daily energy, cost, and session counts
 uvx evnex charge now                 # start charging immediately
 uvx evnex charge auto                # return to the configured schedule

--- a/evnex/api.py
+++ b/evnex/api.py
@@ -47,6 +47,11 @@ from evnex.schema.v3.charge_points import (
 )
 from evnex.schema.v3.commands import EvnexCommandResponse as EvnexCommandResponseV3
 from evnex.schema.v3.generic import EvnexV3APIResponse
+from evnex.schema.v3.locations import EvnexGetLocationsResponse, EvnexLocation
+from evnex.schema.v3.org import (
+    EvnexConnectorSummary,
+    EvnexGetOrgConnectorSummaryResponse,
+)
 
 logger = logging.getLogger("evnex.api")
 
@@ -203,6 +208,38 @@ class Evnex:
         )
         json_data = await self._check_api_response(r)
         return EvnexGetOrgSummaryStatusResponse.model_validate(json_data).data
+
+    @api_retry(HTTPStatusError)
+    async def get_org_locations(self, org_id: str | None = None) -> list[EvnexLocation]:
+        if org_id is None and self.org_id:
+            org_id = self.org_id
+        r = await self._request(
+            "GET",
+            f"/v2/apps/organisations/{org_id}/locations",
+        )
+        json_data = await self._check_api_response(r)
+        return EvnexGetLocationsResponse.model_validate(json_data).data
+
+    @api_retry()
+    async def get_org_connector_summary(
+        self, org_id: str | None = None
+    ) -> EvnexConnectorSummary:
+        """Return per-status connector counts across the organisation.
+
+        This wraps a newer endpoint than get_org_summary_status; the two report
+        the same counts through different response shapes and coexist so callers
+        of either keep working.
+        """
+        if org_id is None and self.org_id:
+            org_id = self.org_id
+        r = await self._request(
+            "GET",
+            f"/organisations/{org_id}/summary/status",
+        )
+        json_data = await self._check_api_response(r)
+        return EvnexGetOrgConnectorSummaryResponse.model_validate(
+            json_data
+        ).data.attributes.connectors
 
     @api_retry()
     async def get_charge_point_detail(

--- a/evnex/cli/_resources.py
+++ b/evnex/cli/_resources.py
@@ -23,6 +23,7 @@ from evnex.api import Evnex
 from evnex.cli._auth import signed_in_auth
 from evnex.schema.charge_points import EvnexChargePoint
 from evnex.schema.v3.charge_points import EvnexChargePointSession
+from evnex.schema.v3.locations import EvnexLocation
 
 
 def _positive_int(value: str) -> int:
@@ -279,6 +280,39 @@ async def cmd_sessions_list(args: argparse.Namespace) -> None:
         _print_table(["Start", "End", "Energy", "Cost"], rows)
 
 
+async def cmd_locations_list(args: argparse.Namespace) -> None:
+    async with open_client(args) as client:
+        await client.get_user_detail()
+        # The retry decorator erases the annotated return type to Any; pin it back.
+        locations: list[EvnexLocation] = await client.get_org_locations()
+
+        if args.json:
+            print(
+                json.dumps([loc.model_dump(mode="json") for loc in locations], indent=2)
+            )
+            return
+
+        rows = []
+        for location in locations:
+            attributes = location.attributes
+            city = attributes.address.city if attributes.address else None
+            retailer = (
+                attributes.icpDetails.electricityRetailer
+                if attributes.icpDetails
+                else None
+            )
+            rows.append(
+                [
+                    attributes.name,
+                    city or "-",
+                    attributes.icpNumber or "-",
+                    retailer or "-",
+                    attributes.timeZone or "-",
+                ]
+            )
+        _print_table(["Name", "City", "ICP", "Retailer", "Timezone"], rows)
+
+
 async def cmd_insights(args: argparse.Namespace) -> None:
     async with open_client(args) as client:
         await client.get_user_detail()
@@ -447,6 +481,21 @@ def add_resource_commands(
         help="maximum number of sessions to show (default 10)",
     )
     sessions_list.set_defaults(func=cmd_sessions_list)
+
+    locations = sub.add_parser(
+        "locations",
+        help="list locations",
+        description="List the organisation's locations.",
+    )
+    locations.set_defaults(print_group_help=locations.print_help)
+    locations_sub = locations.add_subparsers(dest="locations_command")
+
+    locations_list = locations_sub.add_parser(
+        "list",
+        parents=[json_flag, *sign_in],
+        help="list locations (name, city, ICP number, retailer, timezone)",
+    )
+    locations_list.set_defaults(func=cmd_locations_list)
 
     insights = sub.add_parser(
         "insights",

--- a/evnex/schema/v3/locations.py
+++ b/evnex/schema/v3/locations.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class EvnexLocationAddress(BaseModel):
+    address1: str | None = None
+    address2: str | None = None
+    city: str | None = None
+    postCode: str | None = None
+    state: str | None = None
+    country: str | None = None
+
+
+class EvnexLocationCoordinates(BaseModel):
+    latitude: str | None = None
+    longitude: str | None = None
+
+
+class EvnexLocationIcpDetails(BaseModel):
+    electricityRetailer: str | None = None
+    electricityDistributor: str | None = None
+    networkConnectionPoint: str | None = None
+
+
+class EvnexLocationAttributes(BaseModel):
+    name: str
+    address: EvnexLocationAddress | None = None
+    coordinates: EvnexLocationCoordinates | None = None
+    isPublic: bool | None = None
+    updated: datetime | None = None
+    created: datetime | None = None
+    icpNumber: str | None = None
+    icpDetails: EvnexLocationIcpDetails | None = None
+    timeZone: str | None = None
+
+
+class EvnexLocationChargePointRef(BaseModel):
+    type: str
+    id: str
+
+
+class EvnexLocationChargePoints(BaseModel):
+    data: list[EvnexLocationChargePointRef] = Field(default_factory=list)
+
+
+class EvnexLocationRelationships(BaseModel):
+    chargePoints: EvnexLocationChargePoints = Field(
+        default_factory=EvnexLocationChargePoints
+    )
+
+
+class EvnexLocation(BaseModel):
+    id: str
+    type: str
+    attributes: EvnexLocationAttributes
+    relationships: EvnexLocationRelationships = Field(
+        default_factory=EvnexLocationRelationships
+    )
+
+
+class EvnexGetLocationsResponse(BaseModel):
+    data: list[EvnexLocation]

--- a/evnex/schema/v3/org.py
+++ b/evnex/schema/v3/org.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+
+
+class EvnexConnectorSummary(BaseModel):
+    available: int
+    charging: int
+    disabled: int
+    faulted: int
+    occupied: int
+    offline: int
+    reserved: int
+
+
+class EvnexOrgConnectorSummaryAttributes(BaseModel):
+    connectors: EvnexConnectorSummary
+
+
+class EvnexOrgConnectorSummaryData(BaseModel):
+    attributes: EvnexOrgConnectorSummaryAttributes
+
+
+class EvnexGetOrgConnectorSummaryResponse(BaseModel):
+    data: EvnexOrgConnectorSummaryData

--- a/tests/test_cli_resources.py
+++ b/tests/test_cli_resources.py
@@ -24,6 +24,8 @@ from evnex.schema.v3.charge_points import (
 )
 from evnex.schema.v3.charge_points import EvnexGetChargePointSessionsResponse
 from evnex.schema.v3.generic import EvnexV3APIResponse
+from evnex.schema.v3.locations import EvnexGetLocationsResponse
+from evnex.schema.v3.org import EvnexGetOrgConnectorSummaryResponse
 
 BASE = "https://client-api.evnex.io"
 USER_URL = f"{BASE}/v2/apps/user"
@@ -31,6 +33,8 @@ CP_URL = f"{BASE}/v2/apps/organisations/org-0000/charge-points"
 DETAIL_URL = f"{BASE}/charge-points/cp-0000001"
 SESSIONS_URL = f"{BASE}/charge-points/cp-0000001/sessions"
 INSIGHTS_URL = f"{BASE}/organisations/org-0000/summary/insights"
+LOCATIONS_URL = f"{BASE}/v2/apps/organisations/org-0000/locations"
+CONNECTOR_SUMMARY_URL = f"{BASE}/organisations/org-0000/summary/status"
 OVERRIDE_URL = f"{BASE}/charge-points/cp-0000001/commands/set-override"
 STOP_URL = (
     f"{BASE}/v2/apps/organisations/org-0000"
@@ -257,6 +261,75 @@ INSIGHTS_PAYLOAD = {
 }
 
 
+LOCATIONS_PAYLOAD = {
+    "data": [
+        {
+            "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+            "type": "locations",
+            "attributes": {
+                "name": "Home",
+                "address": {
+                    "address1": "1 Test Street",
+                    "address2": "",
+                    "city": "Wellington",
+                    "postCode": "6011",
+                    "state": "",
+                    "country": "NZ",
+                },
+                "coordinates": {"latitude": "-41.2865", "longitude": "174.7762"},
+                "isPublic": False,
+                "updated": "2024-06-01T00:00:00Z",
+                "created": "2024-01-01T00:00:00Z",
+                "icpNumber": "0000123456UN789",
+                "icpDetails": {
+                    "electricityRetailer": "Example Energy",
+                    "electricityDistributor": "Example Networks",
+                    "networkConnectionPoint": "EXP0001",
+                },
+                "timeZone": "Pacific/Auckland",
+            },
+            "relationships": {
+                "chargePoints": {"data": [{"type": "chargePoint", "id": "cp-0000001"}]},
+                "organisation": {"data": None},
+                "users": {"data": []},
+            },
+        }
+    ],
+    # Full charge point objects the client does not model; kept to prove the
+    # response validates with them present.
+    "included": [
+        {
+            "id": "cp-0000001",
+            "type": "chargePoint",
+            "attributes": {"name": "Garage Charger"},
+        }
+    ],
+}
+
+# A location on an account that has not filled in address or ICP details.
+LOCATION_MINIMAL = {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+    "type": "locations",
+    "attributes": {"name": "Depot"},
+}
+
+CONNECTOR_SUMMARY_PAYLOAD = {
+    "data": {
+        "attributes": {
+            "connectors": {
+                "available": 3,
+                "charging": 1,
+                "disabled": 0,
+                "faulted": 0,
+                "occupied": 1,
+                "offline": 2,
+                "reserved": 0,
+            }
+        }
+    }
+}
+
+
 @pytest.fixture
 def cli(resumed_auth, monkeypatch):
     """Patch sign-in so resource handlers use the offline resumed session."""
@@ -297,6 +370,17 @@ def test_fixtures_validate_against_models():
     assert sessions.data[0].attributes.endDate is None
     insights = EvnexGetOrgInsights.model_validate(INSIGHTS_PAYLOAD)
     assert insights.data[0].attributes.sessions == 1
+    locations = EvnexGetLocationsResponse.model_validate(LOCATIONS_PAYLOAD)
+    assert locations.data[0].attributes.address.city == "Wellington"
+    assert locations.data[0].relationships.chargePoints.data[0].id == "cp-0000001"
+    # A location missing its optional sub-objects still validates
+    minimal = EvnexGetLocationsResponse.model_validate({"data": [LOCATION_MINIMAL]})
+    assert minimal.data[0].attributes.address is None
+    assert minimal.data[0].relationships.chargePoints.data == []
+    summary = EvnexGetOrgConnectorSummaryResponse.model_validate(
+        CONNECTOR_SUMMARY_PAYLOAD
+    )
+    assert summary.data.attributes.connectors.available == 3
 
 
 # --- Parser wiring --------------------------------------------------------
@@ -316,6 +400,8 @@ def test_fixtures_validate_against_models():
             "cmd_sessions_list",
             ["sessions", "list", "--charge-point", "cp-1", "--limit", "5", "--json"],
         ),
+        ("cmd_locations_list", ["locations", "list"]),
+        ("cmd_locations_list", ["locations", "list", "--json"]),
         ("cmd_insights", ["insights"]),
         ("cmd_insights", ["insights", "--days", "14", "--json"]),
         ("cmd_charge_now", ["charge", "now", "--charge-point", "cp-1"]),
@@ -529,6 +615,72 @@ async def test_insights(cli, capsys):
     assert "2024-06-10" in out
     assert "1.00 kWh" in out
     assert "1.50 NZD" in out
+
+
+async def test_get_org_locations_returns_data_objects(client):
+    with respx.mock:
+        respx.get(LOCATIONS_URL).mock(
+            return_value=httpx.Response(200, json=LOCATIONS_PAYLOAD)
+        )
+        locations = await client.get_org_locations(org_id="org-0000")
+
+    assert locations[0].id == "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    assert locations[0].attributes.name == "Home"
+    assert locations[0].attributes.address.city == "Wellington"
+    assert locations[0].relationships.chargePoints.data[0].id == "cp-0000001"
+
+
+async def test_get_org_connector_summary(client):
+    with respx.mock:
+        respx.get(CONNECTOR_SUMMARY_URL).mock(
+            return_value=httpx.Response(200, json=CONNECTOR_SUMMARY_PAYLOAD)
+        )
+        summary = await client.get_org_connector_summary(org_id="org-0000")
+
+    assert summary.available == 3
+    assert summary.charging == 1
+    assert summary.offline == 2
+
+
+async def test_locations_list(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(LOCATIONS_URL).mock(
+            return_value=httpx.Response(200, json=LOCATIONS_PAYLOAD)
+        )
+        await run(["locations", "list"])
+
+    out = capsys.readouterr().out
+    assert "Home" in out
+    assert "Wellington" in out
+    assert "0000123456UN789" in out
+    assert "Example Energy" in out
+    assert "Pacific/Auckland" in out
+
+
+async def test_locations_list_json_is_the_only_thing_on_stdout(cli, capsys):
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(LOCATIONS_URL).mock(
+            return_value=httpx.Response(200, json=LOCATIONS_PAYLOAD)
+        )
+        await run(["locations", "list", "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload[0]["id"] == "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+    assert payload[0]["attributes"]["name"] == "Home"
+
+
+async def test_locations_list_handles_missing_address(cli, capsys):
+    payload = {"data": [LOCATION_MINIMAL]}
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        respx.get(LOCATIONS_URL).mock(return_value=httpx.Response(200, json=payload))
+        await run(["locations", "list"])
+
+    out = capsys.readouterr().out
+    # Renders with dashes for the missing fields, no crash
+    assert "Depot" in out
 
 
 async def test_charge_now_sends_override(cli, capsys):


### PR DESCRIPTION
Wraps two endpoints from the app-derived API survey (#119):

- **`get_org_locations()`** — org locations with address, coordinates, ICP number and retailer/distributor details, and related charge point ids. Schema tolerates accounts with sparse location data (only `name` required). Exposed as `evnex locations list [--json]`.
- **`get_org_connector_summary()`** — connector-state counts (available/charging/disabled/faulted/occupied/offline/reserved) from the newer summary endpoint; coexists with the older `get_org_summary_status`.

Left unwrapped per #119: the RFID tokens endpoint (403 on the reference account, schema unverifiable) and the charge point reload command (command name uncaptured).

144 tests; fixtures validated against the new models including a minimal-location case; respx coverage for both methods and the CLI leaf.