### PR TITLE
Bump version to 0.7.0b1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evnex"
-version = "0.7.0"
+version = "0.7.0b1"
 description = "A Python wrapper for the EVNEX Cloud API"
 authors = [{ name = "Brian Thorne", email = "brian@hardbyte.nz" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "evnex"
-version = "0.7.0"
+version = "0.7.0b1"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
First beta of the 0.7 line, for real-world testing before the final release.

0.7 rolls up the auth-lifecycle refactor, MFA management, the `evnex` CLI, the wrapped org endpoints, and the connector-summary / org-id tidy-ups. Cutting it as `0.7.0b1` so it can be installed and exercised end-to-end (including via ha-evnex 0.9.0b1) before promoting to a stable 0.7.0.

`pip`/`uv` will not pick this up as an upgrade unless explicitly requested (`--pre` or an exact `==0.7.0b1` pin).