### PR TITLE
Honor a configured org id and keep --json stdout parseable

### DIFF
--- a/evnex/api.py
+++ b/evnex/api.py
@@ -139,8 +139,9 @@ class Evnex:
         response_json = await self._check_api_response(response)
         data = EvnexGetUserResponse.model_validate(response_json).data
 
-        # Make the assumption that most end users are only in one org
-        if len(data.organisations):
+        # Default to the user's first org, but never override an org_id that
+        # was configured explicitly (EVNEX_ORG_ID) or already resolved.
+        if self.org_id is None and data.organisations:
             self.org_id = data.organisations[0].id
 
         return data

--- a/evnex/api.py
+++ b/evnex/api.py
@@ -140,8 +140,9 @@ class Evnex:
         data = EvnexGetUserResponse.model_validate(response_json).data
 
         # Default to the user's first org, but never override an org_id that
-        # was configured explicitly (EVNEX_ORG_ID) or already resolved.
-        if self.org_id is None and data.organisations:
+        # was configured explicitly (EVNEX_ORG_ID) or already resolved. A blank
+        # EVNEX_ORG_ID counts as unset, matching _resolve_org_id's falsy check.
+        if not self.org_id and data.organisations:
             self.org_id = data.organisations[0].id
 
         return data

--- a/evnex/cli/_auth.py
+++ b/evnex/cli/_auth.py
@@ -86,7 +86,14 @@ async def _challenge_code(args: argparse.Namespace, challenge: AuthChallenge) ->
             sys.exit(1)
         print("Code obtained from --otp-command", file=sys.stderr)
         return code
-    return input(f"Enter the 6-digit code ({challenge.name}): ")
+    # Prompt on stderr so a --json command's stdout stays valid JSON.
+    print(
+        f"Enter the 6-digit code ({challenge.name}): ",
+        end="",
+        file=sys.stderr,
+        flush=True,
+    )
+    return input()
 
 
 async def signed_in_auth(args: argparse.Namespace) -> EvnexAuth:
@@ -102,7 +109,10 @@ async def signed_in_auth(args: argparse.Namespace) -> EvnexAuth:
         except ReauthenticationRequiredError:
             print("Cached session expired; signing in again", file=sys.stderr)
 
-    username = os.environ.get("EVNEX_CLIENT_USERNAME") or input("EVNEX username: ")
+    username = os.environ.get("EVNEX_CLIENT_USERNAME")
+    if not username:
+        print("EVNEX username: ", end="", file=sys.stderr, flush=True)
+        username = input()
     password = os.environ.get("EVNEX_CLIENT_PASSWORD") or getpass.getpass(
         "EVNEX password: "
     )
@@ -223,7 +233,10 @@ async def cmd_change_password(args: argparse.Namespace) -> None:
 async def cmd_reset_password(args: argparse.Namespace) -> None:
     # The forgot-password flow needs no signed-in session.
     auth = EvnexAuth()
-    username = os.environ.get("EVNEX_CLIENT_USERNAME") or input("EVNEX username: ")
+    username = os.environ.get("EVNEX_CLIENT_USERNAME")
+    if not username:
+        print("EVNEX username: ", end="", file=sys.stderr, flush=True)
+        username = input()
     destination = await auth.start_password_reset(username)
     if destination:
         print(f"A reset code was sent to {destination}")

--- a/tests/test_cli_resources.py
+++ b/tests/test_cli_resources.py
@@ -656,6 +656,43 @@ async def test_org_method_without_org_id_raises(client):
     assert time.monotonic() - started < 1.0, "config error was retried, not raised"
 
 
+async def test_get_user_detail_preserves_configured_org(client):
+    # A configured EVNEX_ORG_ID (already on the client) must survive sign-in
+    # rather than being clobbered by the account's first organisation.
+    client.org_id = "configured-org"
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        await client.get_user_detail()
+    assert client.org_id == "configured-org"
+
+
+async def test_get_user_detail_defaults_org_when_unset(client):
+    client.org_id = None
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        await client.get_user_detail()
+    assert client.org_id == "org-0000"
+
+
+async def test_challenge_code_prompts_on_stderr(monkeypatch, capsys):
+    # The MFA prompt must go to stderr so a --json command's stdout stays pure.
+    import argparse
+
+    from evnex.auth import AuthChallenge
+    from evnex.cli._auth import _challenge_code
+
+    monkeypatch.setattr("builtins.input", lambda *a: "123456")
+    args = argparse.Namespace(otp=None, otp_command=None)
+    challenge = AuthChallenge(
+        name="SOFTWARE_TOKEN_MFA", session="s", username="user@example.com"
+    )
+    code = await _challenge_code(args, challenge)
+    captured = capsys.readouterr()
+    assert code == "123456"
+    assert captured.out == ""
+    assert "Enter the 6-digit code" in captured.err
+
+
 async def test_locations_list(cli, capsys):
     with respx.mock:
         respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))

--- a/tests/test_cli_resources.py
+++ b/tests/test_cli_resources.py
@@ -674,6 +674,15 @@ async def test_get_user_detail_defaults_org_when_unset(client):
     assert client.org_id == "org-0000"
 
 
+async def test_get_user_detail_defaults_org_when_blank(client):
+    # A present-but-empty EVNEX_ORG_ID counts as unset and must still default.
+    client.org_id = ""
+    with respx.mock:
+        respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))
+        await client.get_user_detail()
+    assert client.org_id == "org-0000"
+
+
 async def test_challenge_code_prompts_on_stderr(monkeypatch, capsys):
     # The MFA prompt must go to stderr so a --json command's stdout stays pure.
     import argparse


### PR DESCRIPTION
Two fixes for issues raised by automated review on already-merged PRs (#118), verified still present on main:

- **`get_user_detail` clobbered a configured org.** It set `self.org_id = organisations[0].id` unconditionally, overriding an explicitly configured `EVNEX_ORG_ID` on multi-org accounts. Now it only defaults when no org id is set. (The HA coordinator passes `org.id` explicitly and is unaffected; the CLI's no-config default is preserved.)
- **`--json` stdout could be polluted.** The username and MFA-code prompts used `input(prompt)`, which writes to stdout — so a resource command in `--json` mode emitted prompt text before its JSON when an interactive sign-in was triggered. Both prompts now print to stderr (getpass already used stderr).

Tests added: org id preserved-vs-defaulted, and the MFA prompt lands on stderr with clean stdout. 148 tests pass; ruff clean.