### PR TITLE
Fail fast when a set-override command times out

### DIFF
--- a/evnex/api.py
+++ b/evnex/api.py
@@ -317,14 +317,19 @@ class Evnex:
         json_data = await self._check_api_response(r)
         return EvnexChargePointOverrideConfig.model_validate(json_data)
 
-    @api_retry(HTTPStatusError)
+    @api_retry(HTTPStatusError, ReadTimeout)
     async def set_charge_point_override(
         self, charge_point_id: str, charge_now: bool, connector_id: int = 1
     ):
+        # A ReadTimeout means the charge point did not acknowledge the command
+        # in time (typically offline or not responding); fail fast rather than
+        # retrying, which only prolongs the hang and could resubmit the command.
+        # Matches stop_charge_point's policy for the same reason.
         r = await self._request(
             "POST",
             f"/charge-points/{charge_point_id}/commands/set-override",
             json={"connectorId": connector_id, "chargeNow": charge_now},
+            timeout=10,
         )
         self._ensure_success(r)
         return True

--- a/tests/test_cli_resources.py
+++ b/tests/test_cli_resources.py
@@ -702,6 +702,22 @@ async def test_challenge_code_prompts_on_stderr(monkeypatch, capsys):
     assert "Enter the 6-digit code" in captured.err
 
 
+async def test_set_override_fails_fast_on_timeout(client):
+    # A command that times out must fail fast (charge point unresponsive),
+    # not retry-storm through the backoff policy.
+    with respx.mock:
+        route = respx.post(OVERRIDE_URL).mock(
+            side_effect=httpx.ReadTimeout("charge point offline")
+        )
+        started = time.monotonic()
+        with pytest.raises(httpx.ReadTimeout):
+            await client.set_charge_point_override(
+                charge_point_id="cp-0000001", charge_now=True
+            )
+        assert route.call_count == 1, "command was retried instead of failing fast"
+        assert time.monotonic() - started < 1.0
+
+
 async def test_locations_list(cli, capsys):
     with respx.mock:
         respx.get(USER_URL).mock(return_value=httpx.Response(200, json=USER_PAYLOAD))


### PR DESCRIPTION
Surfaced by live testing the beta through Home Assistant: pressing **charge now** against a charge point that wasn't acknowledging (car plugged in but `SuspendedEV`) hung for ~a minute and then failed.

`set_charge_point_override` was the outlier among the command methods — `@api_retry(HTTPStatusError)` (so `ReadTimeout` was **retryable**) with **no bounded timeout**, so a slow/unresponsive charge point retry-stormed through the backoff policy. Every other command already bounds its timeout, and `stop_charge_point` already uses `@api_retry(HTTPStatusError, ReadTimeout)` for exactly this reason.

Fix: bound the request to 10s and exclude `ReadTimeout` from retry, matching `stop_charge_point`. A command timeout means the charge point didn't acknowledge — retrying only prolongs the hang and risks resubmitting a side-effecting command. New test asserts the command is attempted once and returns immediately on timeout.