### PR TITLE
Bump version to 0.7.0b2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evnex"
-version = "0.7.0b1"
+version = "0.7.0b2"
 description = "A Python wrapper for the EVNEX Cloud API"
 authors = [{ name = "Brian Thorne", email = "brian@hardbyte.nz" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "evnex"
-version = "0.7.0b1"
+version = "0.7.0b2"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Second beta of the 0.7 line. Adds, since 0.7.0b1: honor a configured EVNEX_ORG_ID and keep --json stdout parseable (#123), and fail fast when a set-override command times out instead of retry-storming (#124). Install with `uv pip install 'evnex==0.7.0b2'` or `pip install --pre evnex`.