### PR TITLE
Release 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "evnex"
-version = "0.7.0b2"
+version = "0.7.0"
 description = "A Python wrapper for the EVNEX Cloud API"
 authors = [{ name = "Brian Thorne", email = "brian@hardbyte.nz" }]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -384,7 +384,7 @@ wheels = [
 
 [[package]]
 name = "evnex"
-version = "0.7.0b2"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },


### PR DESCRIPTION
Promote the 0.7 line to a stable release (from 0.7.0b2). Highlights of 0.7.0 vs 0.6.1: async, persistence-aware auth lifecycle (`EvnexAuth`/`TokenSet`/`AuthChallenge`, typed errors, reactive 401 recovery); MFA device management, password change and forgot-password flows; the `evnex` CLI; wrapped organisation locations and connector-summary endpoints; configured-org honouring and `--json` stdout purity; and fail-fast command timeouts. `NotAuthorizedException` remains as a deprecated alias (removed in 0.8.0).